### PR TITLE
[Hotfix(config)] Jwt Filter에서 White List 재설정

### DIFF
--- a/src/main/java/nbc/mushroom/domain/user/controller/UserControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/user/controller/UserControllerV1.java
@@ -23,7 +23,7 @@ public class UserControllerV1 {
 
     private final UserService userService;
 
-    @GetMapping("/{userId}")
+    @GetMapping("/{userId}/info")
     public ResponseEntity<ApiResponse<UserRes>> getUser(@PathVariable long userId) {
         UserRes userRes = userService.getUser(userId);
 


### PR DESCRIPTION
## 🔗 연관된 이슈
> ex. #이슈번호

close #13 

## 📝 요약
> 무엇을 했는지 요약

- user 컨트롤러에서 특정 유저 조회를 `/api/users/{userId}/profile` 로 변경
- 필터에서 특정 URL들 검증하도록 변경

## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

<img width="801" alt="스크린샷 2025-02-12 오전 10 59 26" src="https://github.com/user-attachments/assets/ae38c589-e012-49f1-9cec-456b13820b87" />
검증할 WHITE LIST는 위와 같습니다.

## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
