### PR TITLE
[Feature(Bid)] 경매 참여 기능 구현

### DIFF
--- a/src/main/java/nbc/mushroom/domain/bid/controller/BidControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/bid/controller/BidControllerV1.java
@@ -1,7 +1,19 @@
 package nbc.mushroom.domain.bid.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
+import nbc.mushroom.domain.bid.dto.response.CreateBidRes;
 import nbc.mushroom.domain.bid.service.BidService;
+import nbc.mushroom.domain.common.annotation.Auth;
+import nbc.mushroom.domain.common.dto.ApiResponse;
+import nbc.mushroom.domain.common.dto.AuthUser;
+import nbc.mushroom.domain.user.entity.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +23,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class BidControllerV1 {
 
     private final BidService bidService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateBidRes>> createOrUpdateBid(
+        @Auth AuthUser authUser,
+        @PathVariable Long productId,
+        @Valid @RequestBody CreateBidReq createBidReq
+    ) {
+        CreateBidRes createBidRes = bidService.createOrUpdateBid(User.fromAuthUser(authUser),
+            productId,
+            createBidReq);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success("입찰에 성공했습니다.", createBidRes));
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/dto/request/CreateBidReq.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/request/CreateBidReq.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record CreateBidReq(
     @NotNull
-    Long bidPrice
+    Long biddingPrice
 ) {
 
 }

--- a/src/main/java/nbc/mushroom/domain/bid/dto/request/CreateBidReq.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/request/CreateBidReq.java
@@ -1,0 +1,10 @@
+package nbc.mushroom.domain.bid.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateBidReq(
+    @NotNull
+    Long bidPrice
+) {
+
+}

--- a/src/main/java/nbc/mushroom/domain/bid/dto/request/CreateBidReq.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/request/CreateBidReq.java
@@ -3,7 +3,7 @@ package nbc.mushroom.domain.bid.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateBidReq(
-    @NotNull
+    @NotNull(message = "biddingPrice는 필수 값 입니다. ")
     Long biddingPrice
 ) {
 

--- a/src/main/java/nbc/mushroom/domain/bid/dto/response/CreateBidRes.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/response/CreateBidRes.java
@@ -1,5 +1,6 @@
 package nbc.mushroom.domain.bid.dto.response;
 
+import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
 
 public record CreateBidRes(
@@ -7,4 +8,10 @@ public record CreateBidRes(
     BiddingStatus biddingStatus
 ) {
 
+    public static CreateBidRes from(Bid bid) {
+        return new CreateBidRes(
+            bid.getBiddingPrice(),
+            bid.getBiddingStatus()
+        );
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/dto/response/CreateBidRes.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/response/CreateBidRes.java
@@ -1,0 +1,10 @@
+package nbc.mushroom.domain.bid.dto.response;
+
+import nbc.mushroom.domain.bid.entity.BiddingStatus;
+
+public record CreateBidRes(
+    Long biddingPrice,
+    BiddingStatus biddingStatus
+) {
+
+}

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -52,4 +52,8 @@ public class Bid extends Timestamped {
         this.biddingPrice = biddingPrice;
         this.biddingStatus = BiddingStatus.BIDDING;
     }
+
+    public void updateBiddingPrice(Long biddingPrice) {
+        this.biddingPrice = biddingPrice;
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -45,12 +45,11 @@ public class Bid extends Timestamped {
     private BiddingStatus biddingStatus;
 
     @Builder
-    public Bid(Long id, Product product, User bidder, Long biddingPrice,
-        BiddingStatus biddingStatus) {
+    public Bid(Long id, Product product, User bidder, Long biddingPrice) {
         this.id = id;
         this.product = product;
         this.bidder = bidder;
         this.biddingPrice = biddingPrice;
-        this.biddingStatus = biddingStatus;
+        this.biddingStatus = BiddingStatus.BIDDING;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -1,5 +1,11 @@
 package nbc.mushroom.domain.bid.repository;
 
-public interface BidRepositoryCustom {
+import java.util.Optional;
+import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.product.entity.Product;
+import nbc.mushroom.domain.user.entity.User;
 
+public interface BidRepositoryCustom {
+    
+    Optional<Bid> findBidByUserAndProduct(User bidder, Product product);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -1,7 +1,13 @@
 package nbc.mushroom.domain.bid.repository;
 
+import static nbc.mushroom.domain.bid.entity.QBid.bid;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.product.entity.Product;
+import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,4 +15,18 @@ import org.springframework.stereotype.Repository;
 public class BidRepositoryImpl implements BidRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Bid> findBidByUserAndProduct(User bidder, Product product) {
+        return Optional.ofNullable(
+            queryFactory
+                .select(bid)
+                .from(bid)
+                .where(
+                    bid.product.eq(product),
+                    bid.bidder.eq(bidder)
+                )
+                .fetchOne()
+        );
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -31,7 +31,9 @@ public class BidService {
         Bid findBid = bidRepository.findBidByUserAndProduct(loginUser, findProduct)
             .orElseGet(() -> createBid(loginUser, findProduct, createBidReq.biddingPrice()));
 
-        findBid.updateBiddingPrice(createBidReq.biddingPrice());
+        if (!createBidReq.biddingPrice().equals(findBid.getBiddingPrice())) {
+            findBid.updateBiddingPrice(createBidReq.biddingPrice());
+        }
 
         return CreateBidRes.from(findBid);
     }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -29,7 +29,7 @@ public class BidService {
                 ExceptionType.PRODUCT_NOT_FOUND)); // 이 동작을 bid서비스에서 보여주고 싶지 않은데.. Product Repository에 디폴트 메서드 또는 Bid로 반환하는 메서드 생기면 변경하기로
 
         Bid findBid = bidRepository.findBidByUserAndProduct(loginUser, findProduct)
-            .orElseGet(() -> createBid(loginUser, findProduct));
+            .orElseGet(() -> createBid(loginUser, findProduct, createBidReq.biddingPrice()));
 
         findBid.updateBiddingPrice(createBidReq.biddingPrice());
 
@@ -37,9 +37,10 @@ public class BidService {
     }
 
     @Transactional(readOnly = false)
-    public Bid createBid(User bidder, Product product) {
+    public Bid createBid(User bidder, Product product, Long biddingPrice) {
         Bid bid = Bid.builder()
             .product(product)
+            .biddingPrice(biddingPrice)
             .bidder(bidder)
             .build();
 

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -28,13 +28,7 @@ public class BidService {
 
         Product findProduct = productRepository.findProductById(productId);
 
-        if (loginUser == findProduct.getSeller()) {
-            throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
-        }
-
-        if (findProduct.getStartPrice() > createBidReq.biddingPrice()) {
-            throw new CustomException(ExceptionType.INVALID_BIDDING_PRICE);
-        }
+        validateBidRequest(loginUser, findProduct, createBidReq.biddingPrice());
 
         Bid findBid = bidRepository.findBidByUserAndProduct(loginUser, findProduct)
             .orElseGet(() -> createBid(loginUser, findProduct, createBidReq.biddingPrice())
@@ -55,5 +49,14 @@ public class BidService {
             .build();
 
         return bidRepository.save(bid);
+    }
+
+    private void validateBidRequest(User bidder, Product product, Long biddingPrice) {
+        if (bidder == product.getSeller()) {
+            throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
+        }
+        if (product.getStartPrice() > biddingPrice) {
+            throw new CustomException(ExceptionType.INVALID_BIDDING_PRICE);
+        }
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -8,6 +8,7 @@ import nbc.mushroom.domain.bid.repository.BidRepository;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.common.exception.ExceptionType;
 import nbc.mushroom.domain.product.entity.Product;
+import nbc.mushroom.domain.product.entity.ProductStatus;
 import nbc.mushroom.domain.product.repository.ProductRepository;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,9 @@ public class BidService {
     }
 
     private void validateBidRequest(User bidder, Product product, Long biddingPrice) {
+        if (product.getStatus() != ProductStatus.PROGRESSING) {
+            throw new CustomException(ExceptionType.PRODUCT_NOT_IN_PROGRESS);
+        }
         if (bidder == product.getSeller()) {
             throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
         }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -35,4 +35,14 @@ public class BidService {
 
         return CreateBidRes.from(findBid);
     }
+
+    @Transactional(readOnly = false)
+    public Bid createBid(User bidder, Product product) {
+        Bid bid = Bid.builder()
+            .product(product)
+            .bidder(bidder)
+            .build();
+
+        return bidRepository.save(bid);
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -1,7 +1,15 @@
 package nbc.mushroom.domain.bid.service;
 
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
+import nbc.mushroom.domain.bid.dto.response.CreateBidRes;
+import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
+import nbc.mushroom.domain.common.exception.CustomException;
+import nbc.mushroom.domain.common.exception.ExceptionType;
+import nbc.mushroom.domain.product.entity.Product;
+import nbc.mushroom.domain.product.repository.ProductRepository;
+import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,4 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class BidService {
 
     private final BidRepository bidRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = false)
+    public CreateBidRes createOrUpdateBid(User loginUser, Long productId,
+        CreateBidReq createBidReq) {
+        Product findProduct = productRepository.findById(productId)
+            .orElseThrow(() -> new CustomException(
+                ExceptionType.PRODUCT_NOT_FOUND)); // 이 동작을 bid서비스에서 보여주고 싶지 않은데.. Product Repository에 디폴트 메서드 또는 Bid로 반환하는 메서드 생기면 변경하기로
+
+        Bid findBid = bidRepository.findBidByUserAndProduct(loginUser, findProduct)
+            .orElseGet(() -> createBid(loginUser, findProduct));
+
+        findBid.updateBiddingPrice(createBidReq.biddingPrice());
+
+        return CreateBidRes.from(findBid);
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -32,6 +32,10 @@ public class BidService {
             throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
         }
 
+        if (findProduct.getStartPrice() > createBidReq.biddingPrice()) {
+            throw new CustomException(ExceptionType.INVALID_BIDDING_PRICE);
+        }
+
         Bid findBid = bidRepository.findBidByUserAndProduct(loginUser, findProduct)
             .orElseGet(() -> createBid(loginUser, findProduct, createBidReq.biddingPrice())
             ); // 좀 더 생각.. Bid 생성까지 Repository에서 처리하는건 아닌듯..

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -25,6 +25,7 @@ public enum ExceptionType {
 
     //Product
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "P01", "존재하지 않는 상품입니다."),
+    PRODUCT_NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST, "P02", "경매가 진행 중인 상품이 아닙니다."),
 
     //Product Admin
     INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "PA01", "잘못된 상태 변경 요청입니다."),

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -33,6 +33,7 @@ public enum ExceptionType {
 
     // Bid
     SELF_BIDDING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B01", "본인 상품을 입찰할 수 없습니다."),
+    INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "B02", "입찰 금액은 경매 시작 금액 이상이어야 합니다."),
 
     // Like
 

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -32,6 +32,7 @@ public enum ExceptionType {
 
 
     // Bid
+    SELF_BIDDING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B01", "본인 상품을 입찰할 수 없습니다."),
 
     // Like
 


### PR DESCRIPTION
## 🔗 연관된 이슈
> ex. #이슈번호

close #6 


## 📝 요약
> 무엇을 했는지 요약

- (특정 상품) 첫 입찰 시에는 입찰 데이터를 생성하고, 그 이후엔 입찰 가격만 수정할 수 있도록 구현했습니다.
- 자신의 상품은 경매에 참여할 수 없도록 검증 로직을 구현했습니다. 
- 경매 시작가보다 낮은 금액은 참여할 수 없도록 검증 로직을 구현했습니다. 


## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

커밋 실수한 게 있습니다.. 
1. ♻️ fix: Add validation to minimize unnecessary Bid updates -> ✨ feat: 
2. :revycle: -> :re'c'ycle:

createOrUpdateBid()이란 메서드 명 말고 좀 더 적절한게 있는지 고민 중에 있습니다. 

- 동작 확인
   - 특정 상품 첫 입찰 시 데이터가 생김
<img width="368" alt="image" src="https://github.com/user-attachments/assets/c5d4b15b-0e76-4837-8162-84ee16165e4d" />
<img width="799" alt="image" src="https://github.com/user-attachments/assets/e042d941-c9e6-42ba-9bce-d92b6615f4d4" /> 

   - 첫 입찰 후에는 입찰 금액만 수정됨 (row가 더 생기지 않음)
<img width="485" alt="image" src="https://github.com/user-attachments/assets/fba964ca-3a1f-457d-9479-7c9c9263828a" />
<img width="525" alt="image" src="https://github.com/user-attachments/assets/16799f69-2e2d-4bd2-85c1-2fbe6606f07e" />



## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
