### PR TITLE
[Feature(auction_item, bid)] 경매 물품 상태 COMPLETED 변경 기능 구현

### DIFF
--- a/src/main/java/nbc/mushroom/MushroomApplication.java
+++ b/src/main/java/nbc/mushroom/MushroomApplication.java
@@ -5,7 +5,9 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class MushroomApplication {

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
@@ -120,7 +120,7 @@ public class AuctionItem extends Timestamped {
         this.status = AuctionItemStatus.PROGRESSING;
     }
 
-    public void completed() {
+    public void complete() {
         if (this.status != PROGRESSING) {
             throw new CustomException(ExceptionType.INVALID_AUCTION_ITEM_STATUS);
         }

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
@@ -1,6 +1,8 @@
 package nbc.mushroom.domain.auction_item.entity;
 
+import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.COMPLETED;
 import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.INSPECTING;
+import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.PROGRESSING;
 import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.WAITING;
 
 import jakarta.persistence.Column;
@@ -116,5 +118,12 @@ public class AuctionItem extends Timestamped {
             throw new CustomException(ExceptionType.INVALID_AUCTION_ITEM_STATUS);
         }
         this.status = AuctionItemStatus.PROGRESSING;
+    }
+
+    public void completed() {
+        if (this.status != PROGRESSING) {
+            throw new CustomException(ExceptionType.INVALID_AUCTION_ITEM_STATUS);
+        }
+        this.status = COMPLETED;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
@@ -3,6 +3,7 @@ package nbc.mushroom.domain.auction_item.entity;
 import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.COMPLETED;
 import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.INSPECTING;
 import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.PROGRESSING;
+import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.UNTRADED;
 import static nbc.mushroom.domain.auction_item.entity.AuctionItemStatus.WAITING;
 
 import jakarta.persistence.Column;
@@ -125,5 +126,12 @@ public class AuctionItem extends Timestamped {
             throw new CustomException(ExceptionType.INVALID_AUCTION_ITEM_STATUS);
         }
         this.status = COMPLETED;
+    }
+
+    public void untrade() {
+        if (this.status != PROGRESSING) {
+            throw new CustomException(ExceptionType.INVALID_AUCTION_ITEM_STATUS);
+        }
+        this.status = UNTRADED;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItemStatus.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItemStatus.java
@@ -5,5 +5,6 @@ public enum AuctionItemStatus {
     REJECTED,            // 검수실패
     WAITING,             // 대기중
     PROGRESSING,         // 진행중
-    COMPLETED            // 종료
+    COMPLETED,            // 종료
+    UNTRADED              // 거래 실패
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
@@ -19,4 +19,7 @@ public interface AuctionItemRepositoryCustom {
         LocalDateTime now);
 
     boolean existsByUserAndAuctionItem(User user, Long auctionItemId);
+
+    List<AuctionItem> findAuctionItemsByStatusAndEndTime(AuctionItemStatus auctionItemStatus,
+        LocalDateTime now);
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -95,4 +95,17 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .fetchOne() != null;
 
     }
+
+    @Override
+    public List<AuctionItem> findAuctionItemsByStatusAndEndTime(AuctionItemStatus auctionItemStatus,
+        LocalDateTime now) {
+        return queryFactory.select(auctionItem)
+            .from(auctionItem)
+            .where(
+                auctionItem.status.eq(auctionItemStatus),
+                auctionItem.endTime.eq(now),
+                auctionItem.isDeleted.isFalse()
+            )
+            .fetch();
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -52,12 +52,9 @@ public class AuctionItemStatusService {
             Bid succedBid = bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem);
             succedBid.succeed();
 
-            List<Bid> failedBids = bidRepository.findPotentiallyFailedBidsByAuctionItem(
-                auctionItem);
-
-            for (Bid bid : failedBids) {
-                bid.fail();
-            }
+            // 최고가 아닌 Bid들을 fail 처리
+            bidRepository.findPotentiallyFailedBidsByAuctionItem(auctionItem)
+                .forEach(Bid::fail);
         }
     }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -42,16 +42,16 @@ public class AuctionItemStatusService {
             AuctionItemStatus.PROGRESSING, now);
 
         for (AuctionItem auctionItem : progressingAuctionItems) {
-            auctionItem.completed();
+            auctionItem.complete();
 
-            Bid succedBid = bidRepository.findPotentiallysucceedBidByAuctionItem(auctionItem);
+            Bid succedBid = bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem);
             succedBid.succeed();
 
             List<Bid> failedBids = bidRepository.findPotentiallyFailedBidsByAuctionItem(
                 auctionItem);
-            
+
             for (Bid bid : failedBids) {
-                bid.failed();
+                bid.fail();
             }
         }
     }

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -44,6 +44,11 @@ public class AuctionItemStatusService {
         for (AuctionItem auctionItem : progressingAuctionItems) {
             auctionItem.complete();
 
+            if (!bidRepository.existsBidByAuctionItem(auctionItem)) {
+                auctionItem.untrade();
+                continue;
+            }
+
             Bid succedBid = bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem);
             succedBid.succeed();
 

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -59,7 +59,7 @@ public class Bid extends Timestamped {
         this.biddingPrice = biddingPrice;
     }
 
-    public void failed() {
+    public void fail() {
         if (this.biddingStatus != BiddingStatus.BIDDING) {
             throw new CustomException(ExceptionType.INVALID_BID_STATUS);
         }

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -17,6 +17,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.common.entity.Timestamped;
+import nbc.mushroom.domain.common.exception.CustomException;
+import nbc.mushroom.domain.common.exception.ExceptionType;
 import nbc.mushroom.domain.user.entity.User;
 
 @Getter
@@ -55,5 +57,12 @@ public class Bid extends Timestamped {
 
     public void updateBiddingPrice(Long biddingPrice) {
         this.biddingPrice = biddingPrice;
+    }
+
+    public void failed() {
+        if (this.biddingStatus != BiddingStatus.BIDDING) {
+            throw new CustomException(ExceptionType.INVALID_BID_STATUS);
+        }
+        this.biddingStatus = BiddingStatus.FAILED;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -65,4 +65,11 @@ public class Bid extends Timestamped {
         }
         this.biddingStatus = BiddingStatus.FAILED;
     }
+
+    public void succeed() {
+        if (this.biddingStatus != BiddingStatus.BIDDING) {
+            throw new CustomException(ExceptionType.INVALID_BID_STATUS);
+        }
+        this.biddingStatus = BiddingStatus.SUCCEED;
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -10,7 +10,7 @@ public interface BidRepositoryCustom {
 
     Optional<Bid> findBidByUserAndAuctionItem(User bidder, AuctionItem auctionItem);
 
-    Bid findPotentiallysucceedBidByAuctionItem(AuctionItem auctionItem);
+    Bid findPotentiallySucceededBidByAuctionItem(AuctionItem auctionItem);
 
     List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -8,4 +8,6 @@ import nbc.mushroom.domain.user.entity.User;
 public interface BidRepositoryCustom {
 
     Optional<Bid> findBidByUserAndAuctionItem(User bidder, AuctionItem auctionItem);
+
+    Bid findPotentiallysucceedBidByAuctionItem(AuctionItem auctionItem);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface BidRepositoryCustom {
     Bid findPotentiallySucceededBidByAuctionItem(AuctionItem auctionItem);
 
     List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem);
+
+    Boolean existsBidByAuctionItem(AuctionItem auctionItem);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -1,5 +1,6 @@
 package nbc.mushroom.domain.bid.repository;
 
+import java.util.List;
 import java.util.Optional;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.bid.entity.Bid;
@@ -10,4 +11,6 @@ public interface BidRepositoryCustom {
     Optional<Bid> findBidByUserAndAuctionItem(User bidder, AuctionItem auctionItem);
 
     Bid findPotentiallysucceedBidByAuctionItem(AuctionItem auctionItem);
+
+    List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -29,4 +29,15 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
                 .fetchOne()
         );
     }
+
+    @Override
+    public Bid findPotentiallysucceedBidByAuctionItem(AuctionItem auctionItem) {
+        return queryFactory
+            .select(bid)
+            .from(bid)
+            .where(bid.auctionItem.eq(auctionItem))
+            .orderBy(bid.biddingPrice.desc())
+            .limit(1)
+            .fetchOne();
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -63,4 +63,13 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
             )
             .fetch();
     }
+
+    @Override
+    public Boolean existsBidByAuctionItem(AuctionItem auctionItem) {
+        return queryFactory
+            .select(bid.count())
+            .from(bid)
+            .where(bid.auctionItem.eq(auctionItem))
+            .fetchOne() != null;
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -34,7 +34,7 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
     }
 
     @Override
-    public Bid findPotentiallysucceedBidByAuctionItem(AuctionItem auctionItem) {
+    public Bid findPotentiallySucceededBidByAuctionItem(AuctionItem auctionItem) {
         return queryFactory
             .select(bid)
             .from(bid)

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -2,11 +2,14 @@ package nbc.mushroom.domain.bid.repository;
 
 import static nbc.mushroom.domain.bid.entity.QBid.bid;
 
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.bid.entity.QBid;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Repository;
 
@@ -39,5 +42,25 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
             .orderBy(bid.biddingPrice.desc())
             .limit(1)
             .fetchOne();
+    }
+
+
+    @Override
+    public List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem) {
+
+        QBid subBid = new QBid("subBid");
+
+        return queryFactory
+            .select(bid)
+            .from(bid)
+            .where(
+                bid.auctionItem.eq(auctionItem),
+                bid.biddingPrice.ne(JPAExpressions
+                    .select(subBid.biddingPrice.max())
+                    .from(subBid)
+                    .where(subBid.auctionItem.eq(auctionItem))
+                )
+            )
+            .fetch();
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -1,5 +1,6 @@
 package nbc.mushroom.domain.bid.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
@@ -62,10 +63,13 @@ public class BidService {
             throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
         }
 
-        Bid highestBid = bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem);
+        //  경매물품 Bid의 최고가 반환, 조회되는 bid 데이터가 없으면 acutionItem을 최고가로 설정
+        Long highestBiddingPrice = Optional.ofNullable(
+                bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem))
+            .map(Bid::getBiddingPrice)
+            .orElse(auctionItem.getStartPrice());
 
-        if (auctionItem.getStartPrice() > biddingPrice
-            && highestBid.getBiddingPrice() >= biddingPrice) {
+        if (highestBiddingPrice >= biddingPrice) {
             throw new CustomException(ExceptionType.INVALID_BIDDING_PRICE);
         }
     }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -61,7 +61,11 @@ public class BidService {
         if (bidder == auctionItem.getSeller()) {
             throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
         }
-        if (auctionItem.getStartPrice() > biddingPrice) {
+
+        Bid highestBid = bidRepository.findPotentiallysucceedBidByAuctionItem(auctionItem);
+
+        if (auctionItem.getStartPrice() > biddingPrice
+            && highestBid.getBiddingPrice() >= biddingPrice) {
             throw new CustomException(ExceptionType.INVALID_BIDDING_PRICE);
         }
     }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -62,7 +62,7 @@ public class BidService {
             throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
         }
 
-        Bid highestBid = bidRepository.findPotentiallysucceedBidByAuctionItem(auctionItem);
+        Bid highestBid = bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem);
 
         if (auctionItem.getStartPrice() > biddingPrice
             && highestBid.getBiddingPrice() >= biddingPrice) {

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -35,7 +35,7 @@ public enum ExceptionType {
 
     // Bid
     SELF_BIDDING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B01", "본인 물품을 입찰할 수 없습니다."),
-    INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "B02", "입찰 금액은 경매 시작 금액 이상이어야 합니다."),
+    INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "B02", "입찰 금액은 현재 최고 입찰가 이상이어야 합니다."),
 
     // Like
     EXIST_LIKE_BY_AUCTION_ITEM(HttpStatus.BAD_REQUEST, "L01", "좋아요는 경매 물품 하나 당 한 번만 가능합니다."),

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -36,6 +36,7 @@ public enum ExceptionType {
     // Bid
     SELF_BIDDING_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "B01", "본인 물품을 입찰할 수 없습니다."),
     INVALID_BIDDING_PRICE(HttpStatus.BAD_REQUEST, "B02", "입찰 금액은 현재 최고 입찰가 이상이어야 합니다."),
+    INVALID_BID_STATUS(HttpStatus.BAD_REQUEST, "B03", "잘못된 입찰 상태 변경 요청입니다."),
 
     // Like
     EXIST_LIKE_BY_AUCTION_ITEM(HttpStatus.BAD_REQUEST, "L01", "좋아요는 경매 물품 하나 당 한 번만 가능합니다."),


### PR DESCRIPTION
## 🔗 연관된 이슈
> ex. #이슈번호

close #25

## 📝 요약
> 무엇을 했는지 요약

- 판매자가 지정한 경매 종료 시간에 `PROGRESSING`에서 `COMPLETED`로 변경되어 경매가 종료될 수 있도록 구현했습니다. 
- 경매 종료 시 `Bid`의 상태도 `FAILED` 혹은 `SUCCEED` 로 바뀌어 결과를 확인할 수 있도록 구현했습니다.
    -  최고 입찰가 BIDDING -> SUCCEED
    -  그 외 BIDDING -> FAILED
- `BiddingPrice` 입력 시 입찰 시간 기준 입찰 최고가 이상만 입력할 수 있도록 검증 로직을 추가하였습니다. 
- `@EnableScheduling`가 누락되어 있는 것을 발견했습니다. 어노테이션 추가 후 스케줄러가 정상 실행 되도록 수정했습니다. 
 
+) 2/14 13:00 추가사항
- 경매 물품에 해당하는 입찰 내역이 없을 시 경매 물품이 거래 취소(`UNTRADED`)되는 로직을 추가했습니다. 
- BidService.validateBidRequest 메서드에서 발생할 수 있는 null pointer exception 문제를 해결했습니다. 

## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

1. (사진엔 누락, Auction_item.id = 2) 경매 진행 중
![image](https://github.com/user-attachments/assets/d1489f74-9ad9-4800-8487-074f072640e5)

2. 3명의 사용자가 입찰 중 (순서대로 사용자 1,2,3)
![image](https://github.com/user-attachments/assets/1bda9f9d-fd2c-408b-a1e0-dda2acb54d1d)

3. 경매 종료
![image](https://github.com/user-attachments/assets/323ab38c-5a2a-434b-ab17-7d8af015d083)

4. 입찰 결과. 최고가를 입력한 사용자3의 결과는 `SUCCEED`, 그 외 사용자의 결과는 `FAILED`
![image](https://github.com/user-attachments/assets/767de73b-278a-4648-8ca1-06b9277070cf)


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
