### PR TITLE
[Feature(user, bid)] 입찰 내역 목록 조회 기능 구현

### DIFF
--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface BidRepositoryCustom {
 
@@ -15,4 +17,6 @@ public interface BidRepositoryCustom {
     List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem);
 
     Boolean existsBidByAuctionItem(AuctionItem auctionItem);
+
+    Page<Bid> findBidsByUser(User user, Pageable pageable);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -3,6 +3,7 @@ package nbc.mushroom.domain.bid.repository;
 import static nbc.mushroom.domain.bid.entity.QBid.bid;
 
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,9 @@ import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.QBid;
 import nbc.mushroom.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -71,5 +75,25 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
             .from(bid)
             .where(bid.auctionItem.eq(auctionItem))
             .fetchOne() != null;
+    }
+
+    @Override
+    public Page<Bid> findBidsByUser(User user, Pageable pageable) {
+
+        List<Bid> content = queryFactory
+            .select(bid)
+            .from(bid)
+            .where(bid.bidder.eq(user))
+            .orderBy(bid.createdAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> queryCount = queryFactory
+            .select(bid.count())
+            .from(bid)
+            .where(bid.bidder.eq(user));
+
+        return PageableExecutionUtils.getPage(content, pageable, queryCount::fetchOne);
     }
 }

--- a/src/main/java/nbc/mushroom/domain/user/controller/UserBidControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/user/controller/UserBidControllerV1.java
@@ -1,0 +1,15 @@
+package nbc.mushroom.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.user.service.UserBidService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users/bids")
+@RequiredArgsConstructor
+public class UserBidControllerV1 {
+
+    private final UserBidService userBidService;
+
+}

--- a/src/main/java/nbc/mushroom/domain/user/controller/UserBidControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/user/controller/UserBidControllerV1.java
@@ -1,8 +1,20 @@
 package nbc.mushroom.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.common.annotation.Auth;
+import nbc.mushroom.domain.common.dto.ApiResponse;
+import nbc.mushroom.domain.common.dto.AuthUser;
+import nbc.mushroom.domain.user.dto.response.UserBidRes;
+import nbc.mushroom.domain.user.entity.User;
 import nbc.mushroom.domain.user.service.UserBidService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,4 +24,17 @@ public class UserBidControllerV1 {
 
     private final UserBidService userBidService;
 
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<UserBidRes>>> getUserBidHistory(
+        @Auth AuthUser authUser,
+        @RequestParam(defaultValue = "1") int page
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, 10);
+        User loginUser = User.fromAuthUser(authUser);
+
+        Page<UserBidRes> getUserBidRes = userBidService.getUserBidHistory(loginUser, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ApiResponse.success("입찰 내역 목록 조회에 성공했습니다", getUserBidRes));
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/user/dto/response/GetUserBidRes.java
+++ b/src/main/java/nbc/mushroom/domain/user/dto/response/GetUserBidRes.java
@@ -1,0 +1,22 @@
+package nbc.mushroom.domain.user.dto.response;
+
+import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
+import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.bid.entity.BiddingStatus;
+
+public record GetUserBidRes(
+    Long bidId,
+    Long biddingPrice,
+    BiddingStatus biddingStatus,
+    SearchAuctionItemRes searchAuctionItemRes
+) {
+
+    public static GetUserBidRes from(Bid bid, SearchAuctionItemRes searchAuctionItemRes) {
+        return new GetUserBidRes(
+            bid.getId(),
+            bid.getBiddingPrice(),
+            bid.getBiddingStatus(),
+            searchAuctionItemRes
+        );
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/user/dto/response/UserBidRes.java
+++ b/src/main/java/nbc/mushroom/domain/user/dto/response/UserBidRes.java
@@ -4,15 +4,15 @@ import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
 
-public record GetUserBidRes(
+public record UserBidRes(
     Long bidId,
     Long biddingPrice,
     BiddingStatus biddingStatus,
     SearchAuctionItemRes searchAuctionItemRes
 ) {
 
-    public static GetUserBidRes from(Bid bid, SearchAuctionItemRes searchAuctionItemRes) {
-        return new GetUserBidRes(
+    public static UserBidRes from(Bid bid, SearchAuctionItemRes searchAuctionItemRes) {
+        return new UserBidRes(
             bid.getId(),
             bid.getBiddingPrice(),
             bid.getBiddingStatus(),

--- a/src/main/java/nbc/mushroom/domain/user/service/UserBidService.java
+++ b/src/main/java/nbc/mushroom/domain/user/service/UserBidService.java
@@ -1,0 +1,10 @@
+package nbc.mushroom.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserBidService {
+
+}

--- a/src/main/java/nbc/mushroom/domain/user/service/UserBidService.java
+++ b/src/main/java/nbc/mushroom/domain/user/service/UserBidService.java
@@ -1,10 +1,25 @@
 package nbc.mushroom.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
+import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.bid.repository.BidRepository;
+import nbc.mushroom.domain.user.dto.response.UserBidRes;
+import nbc.mushroom.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserBidService {
 
+    private final BidRepository bidRepository;
+
+    public Page<UserBidRes> getUserBidHistory(User loginUser, Pageable pageable) {
+        Page<Bid> bidPage = bidRepository.findBidsByUser(loginUser, pageable);
+
+        return bidPage.map(bid ->
+            UserBidRes.from(bid, SearchAuctionItemRes.from(bid.getAuctionItem())));
+    }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
> ex. #이슈번호

close #38 

## 📝 요약
> 무엇을 했는지 요약

마이페이지에서 보여질 로그인 한 유저의 입찰 내역 목록만 조회될 수 있도록 구현했습니다. 

## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

- 아직 병합되지 않은 PR #35 에 연관된 브랜치에서 파생된 브랜치라 관련 커밋 내역이 아직 뜹니다! 
병합 됐는데도 관련 커밋 내역이 뜬다면 rebase 후 해당 PR 병합 하겠습니다.  
(🧹 chore: Add basic structure for UserBidService and UserBidControllerV1 여기서부터 보시면 됩니다)

- Postman 실행 결과
<img width="776" alt="image" src="https://github.com/user-attachments/assets/0b6350bf-76ef-407c-875a-939b721658a3" />


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
