### PR TITLE
[BUG(auction_item, bid)] 경매 물품 상태, 입찰 결과 변경 오류 수정

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -86,7 +86,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .from(auctionItem)
             .where(
                 auctionItem.status.eq(auctionItemStatus),
-                auctionItem.startTime.eq(now),
+                auctionItem.startTime.goe(now).and(auctionItem.startTime.loe(now.plusMinutes(1))),
                 auctionItem.isDeleted.isFalse()
             )
             .fetch();
@@ -252,7 +252,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .from(auctionItem)
             .where(
                 auctionItem.status.eq(auctionItemStatus),
-                auctionItem.endTime.eq(now),
+                auctionItem.endTime.goe(now).and(auctionItem.endTime.loe(now.plusMinutes(1))),
                 auctionItem.isDeleted.isFalse()
             )
             .fetch();

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
 import nbc.mushroom.domain.auction_item.repository.AuctionItemRepository;
@@ -13,6 +14,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuctionItemStatusService {
@@ -42,14 +44,16 @@ public class AuctionItemStatusService {
             AuctionItemStatus.PROGRESSING, now);
 
         for (AuctionItem auctionItem : progressingAuctionItems) {
+            log.info("auction ID : {}", auctionItem.getId().toString());
             auctionItem.complete();
 
-            if (!bidRepository.existsBidByAuctionItem(auctionItem)) {
+            if (Boolean.FALSE.equals(bidRepository.existsBidByAuctionItem(auctionItem))) {
                 auctionItem.untrade();
                 continue;
             }
 
             Bid succedBid = bidRepository.findPotentiallySucceededBidByAuctionItem(auctionItem);
+            log.info("succedBid ID : {}", succedBid.getId().toString());
             succedBid.succeed();
 
             // 최고가 아닌 Bid들을 fail 처리

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -73,10 +73,10 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
     @Override
     public Boolean existsBidByAuctionItem(AuctionItem auctionItem) {
         return queryFactory
-            .select(bid.count())
+            .select(bid)
             .from(bid)
             .where(bid.auctionItem.eq(auctionItem))
-            .fetchOne() != null;
+            .fetchFirst() != null;
     }
 
     @Override


### PR DESCRIPTION
## 🔗 연관된 이슈
> ex. #이슈번호

close #45

## 📝 요약
> 무엇을 했는지 요약

- 경매 물품, 입찰 상태 변경이 정상적으로 작동할 수 있도록 쿼리 수정. 
- existsBidByAuctionItem() 메서드 수정
     - 이전까진 bid 데이터의 개수만 가져오도록 구현되어 있어 null 이 발생할 일이 생기지 않음 -> 의도와 다른 구현
     - select(bid.count())을 select(bid)로 수정
     - 위 사항을 수정함에 따라 fetchOne()을 fetchFirst()로 수정
- startTime, endTime이 x분 ~ x+1분 사이에 해당하는 경매 물품의 상태를 변경되도록 수정

## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

제 로컬에선 잘 돌아가서 올립니다..!
<img width="512" alt="image" src="https://github.com/user-attachments/assets/dc95de8a-522c-4c1b-bbb5-d1217d649605" />
![image](https://github.com/user-attachments/assets/2737a88a-9740-4cd3-9552-a8628a8bb27d)



## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
