### PR TITLE
[Bug(auction_item)] 경매 물품 결과가 UNTRADED에 해당할 시 예외처리가 되는 오류 수정 

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -86,7 +86,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .from(auctionItem)
             .where(
                 auctionItem.status.eq(auctionItemStatus),
-                auctionItem.startTime.goe(now).and(auctionItem.startTime.loe(now.plusMinutes(1))),
+                auctionItem.startTime.between(now, now.withSecond(59)),
                 auctionItem.isDeleted.isFalse()
             )
             .fetch();
@@ -261,7 +261,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .from(auctionItem)
             .where(
                 auctionItem.status.eq(auctionItemStatus),
-                auctionItem.endTime.goe(now).and(auctionItem.endTime.loe(now.plusMinutes(1))),
+                auctionItem.endTime.between(now, now.withSecond(59)),
                 auctionItem.isDeleted.isFalse()
             )
             .fetch();

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -46,9 +46,12 @@ public class AuctionItemStatusService {
         for (AuctionItem auctionItem : progressingAuctionItems) {
             log.info("auction ID : {}", auctionItem.getId().toString());
             auctionItem.complete();
+            log.info("auction Status : {}", auctionItem.getStatus());
 
             if (Boolean.FALSE.equals(bidRepository.existsBidByAuctionItem(auctionItem))) {
                 auctionItem.untrade();
+                log.info("auction untrade id : {}", auctionItem.getId());
+                log.info("auction untrade Status : {}", auctionItem.getStatus());
                 continue;
             }
 

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -1,7 +1,9 @@
 package nbc.mushroom.domain.bid.service;
 
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
 import nbc.mushroom.domain.auction_item.repository.AuctionItemRepository;
@@ -15,6 +17,7 @@ import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -59,7 +62,10 @@ public class BidService {
         if (auctionItem.getStatus() != AuctionItemStatus.PROGRESSING) {
             throw new CustomException(ExceptionType.AUCTION_ITEM_NOT_IN_PROGRESS);
         }
-        if (bidder == auctionItem.getSeller()) {
+
+        log.info("bidder id : {}", bidder.getId());
+        log.info("seller id : {}", auctionItem.getSeller().getId());
+        if (Objects.equals(bidder.getId(), auctionItem.getSeller().getId())) {
             throw new CustomException(ExceptionType.SELF_BIDDING_NOT_ALLOWED);
         }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
> ex. #이슈번호

close #53 

## 📝 요약
> 무엇을 했는지 요약

경매 종료 시 입찰 내역이 없는 경매 물품의 상태가 정상적으로 UNTRADED로 변경되도록 수정하였습니다. 
경매 시작/종료 시간을 더 정밀하게 조회될 수 있도록 수정했습니다. (기존엔 현재 시간이 5분이라면, 5분 00초 ~ 6분 59초까지 해당하는 데이터들을 조회함. 이를 수정해 5분 00초 ~ 59초에 해당하는 데이터들만 조회되도록 범위를 좁힘)

## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

![image](https://github.com/user-attachments/assets/6a554972-b956-4d3b-ae07-f087da0290b4)


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
