### PR TITLE
[Feature(admin)] 관리자 경매 물품 상태 목록 전체 조회 및 필터링 조회 기능 구현 

### DIFF
--- a/src/main/java/nbc/mushroom/domain/admin/controller/AuctionItemAdminControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/admin/controller/AuctionItemAdminControllerV1.java
@@ -1,16 +1,23 @@
-package nbc.mushroom.domain.auction_item.controller;
+package nbc.mushroom.domain.admin.controller;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import nbc.mushroom.domain.auction_item.service.AuctionItemAdminService;
+import nbc.mushroom.domain.admin.dto.response.AuctionItemStatusRes;
+import nbc.mushroom.domain.admin.service.AuctionItemAdminService;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
 import nbc.mushroom.domain.common.dto.ApiResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auction-items/admin")
+@RequestMapping("/api/v1/admin/auction-items")
 @RequiredArgsConstructor
 public class AuctionItemAdminControllerV1 {
 
@@ -37,5 +44,17 @@ public class AuctionItemAdminControllerV1 {
         return ResponseEntity.ok(
             ApiResponse.success("관리자가 경매 물품을 반려했습니다.")
         );
+    }
+
+    // 관리자 경매 물품 상태 목록 전체 조회 + 필터링 조회 기능 API
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<AuctionItemStatusRes>>> adminSearchAuctionItemsStatus(
+        @RequestParam(required = false) List<AuctionItemStatus> status, Pageable pageable) {
+
+        Page<AuctionItemStatusRes> auctionItemsStatus = auctionItemAdminService.getAuctionItemsStatus(
+            status, pageable);
+
+        return ResponseEntity.ok(
+            ApiResponse.success("경매 물품 상태 목록을 조회했습니다.", auctionItemsStatus));
     }
 }

--- a/src/main/java/nbc/mushroom/domain/admin/dto/response/AuctionItemStatusRes.java
+++ b/src/main/java/nbc/mushroom/domain/admin/dto/response/AuctionItemStatusRes.java
@@ -1,0 +1,51 @@
+package nbc.mushroom.domain.admin.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemCategory;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemSize;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
+
+public record AuctionItemStatusRes(
+    Long auctionItemId,
+    String name,
+    String description,
+    String imageUrl,
+    AuctionItemSize size,
+    AuctionItemCategory category,
+    String brand,
+    Long startPrice,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    AuctionItemStatus status
+) {
+
+    // QueryProjection 애너테이션을 사용하기 위해 추가한 생성자
+    @QueryProjection
+    public AuctionItemStatusRes(
+        Long auctionItemId,
+        String name,
+        String description,
+        String imageUrl,
+        AuctionItemSize size,
+        AuctionItemCategory category,
+        String brand,
+        Long startPrice,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        AuctionItemStatus status
+    ) {
+        this.auctionItemId = auctionItemId;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.size = size;
+        this.category = category;
+        this.brand = brand;
+        this.startPrice = startPrice;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = status;
+    }
+}
+

--- a/src/main/java/nbc/mushroom/domain/admin/service/AuctionItemAdminService.java
+++ b/src/main/java/nbc/mushroom/domain/admin/service/AuctionItemAdminService.java
@@ -1,11 +1,18 @@
-package nbc.mushroom.domain.auction_item.service;
+package nbc.mushroom.domain.admin.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nbc.mushroom.domain.admin.dto.response.AuctionItemStatusRes;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
 import nbc.mushroom.domain.auction_item.repository.AuctionItemRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuctionItemAdminService {
@@ -28,5 +35,17 @@ public class AuctionItemAdminService {
         AuctionItem auctionItem = auctionItemRepository.findAuctionItemById(auctionItemId);
 
         auctionItem.reject();
+    }
+
+    // 관리자 경매 물품 상태 목록 전체 조회 + 상태별 필터링 조회
+    @Transactional(readOnly = true)
+    public Page<AuctionItemStatusRes> getAuctionItemsStatus(List<AuctionItemStatus> status,
+        Pageable pageable) {
+
+        if (status != null && !status.isEmpty()) {
+            return auctionItemRepository.findAuctionItemsByStatus(status, pageable);
+        } else {
+            return auctionItemRepository.findAllAuctionItemsByStatus(pageable);
+        }
     }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
@@ -129,7 +129,7 @@ public class AuctionItem extends Timestamped {
         this.status = COMPLETED;
     }
 
-    public void untrade() {
+    public void untrade() { // TODO 메서드명도 non traded로 변경하기
         if (this.status != PROGRESSING) {
             throw new CustomException(INVALID_AUCTION_ITEM_STATUS);
         }

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItemStatus.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItemStatus.java
@@ -6,5 +6,5 @@ public enum AuctionItemStatus {
     WAITING,             // 대기중
     PROGRESSING,         // 진행중
     COMPLETED,            // 종료
-    UNTRADED              // 거래 실패
+    UNTRADED              // 거래 실패 TODO NON_TRADED로 변경하기
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
@@ -2,6 +2,7 @@ package nbc.mushroom.domain.auction_item.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import nbc.mushroom.domain.admin.dto.response.AuctionItemStatusRes;
 import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemCategory;
@@ -31,4 +32,11 @@ public interface AuctionItemRepositoryCustom {
         String sort, String sortOrder, String keyword, String brand, AuctionItemCategory category,
         AuctionItemSize size, LocalDateTime startDate, LocalDateTime endDate,
         Long minPrice, Long maxPrice, Pageable pageable);
+
+    // 경매 물품 상태별 필터링 조회
+    Page<AuctionItemStatusRes> findAuctionItemsByStatus(
+        List<AuctionItemStatus> status, Pageable pageable);
+
+    // 경매 물품 상태 목록 전체 조회
+    Page<AuctionItemStatusRes> findAllAuctionItemsByStatus(Pageable pageable);
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -72,7 +72,10 @@ public class BidService {
         if (Objects.equals(bidder.getId(), auctionItem.getSeller().getId())) {
             throw new CustomException(SELF_BIDDING_NOT_ALLOWED);
         }
-
+        if (bidder == auctionItem.getSeller()) {
+            throw new CustomException(
+                SELF_BIDDING_NOT_ALLOWED); // todo 하영님이 고쳐서 주신다고 했음! PR때 고쳐져있는지 확인하기
+        }
         if (auctionItem.getStartPrice() > biddingPrice) {
             throw new CustomException(INVALID_BIDDING_PRICE);
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
> close #56



## 📝 요약
> 관리자가 경매 물품의 상태를 전체 목록으로 조회하거나 필터링으로 원하는 조건의 상태인 경매 물품만을 조회할 수 있습니다.  



## 💬 참고사항
> @QueryProjection 애너테이션을 이용해 코드 가독성을 높여보려고 했으나, 큰 차이는 없는 듯합니다. 관련 내용은 [5분 기록보드](https://www.notion.so/yeim/5-19416458a6bf80af84c4feb0ecc05c7c?p=19d16458a6bf801cb24ec6a3f9b2de7b&pm=s)에 있으니, 읽어보실 분은 읽어보시고 더 좋은 방법을 알고계시면 공유해주세요! 

> TEST 시 엔드포인트 형식, 예시 응답 
![image](https://github.com/user-attachments/assets/cd65df12-9997-4253-8a4a-57edd1703412)



## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
