### PR TITLE
[BUG(admin)] Auction Item Repository에서 경매 물품 상태 목록 조회 메서드에 Nullability warning 해결 

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -24,7 +24,6 @@ import nbc.mushroom.domain.auction_item.entity.QAuctionItem;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -221,13 +220,12 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        long total = queryFactory
+        JPAQuery<Long> total = queryFactory
             .select(auctionItem.count())
             .from(auctionItem)
-            .where(builder)
-            .fetchOne();
+            .where(builder);
 
-        return new PageImpl<>(results, pageable, total);
+        return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
     }
 
     // 경매 물품 상태 목록 전체 조회 메서드
@@ -253,12 +251,11 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        long total = queryFactory
+        JPAQuery<Long> total = queryFactory
             .select(auctionItem.count())
-            .from(auctionItem)
-            .fetchOne();
+            .from(auctionItem);
 
-        return PageableExecutionUtils.getPage(results, pageable, () -> total);
+        return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
     }
 
     private OrderSpecifier<?>[] getSortOrders(Pageable pageable) {


### PR DESCRIPTION
## 🔗 연관된 이슈
> close #70 



## 📝 요약
> Nullability warning으로 null이 반환될 수 있다는 경고 메시지를 해결하고 프로젝트의 전체적인 통일성을 위해 반환 방식을 PageableExecutionUtils.getPage()로 변경했습니다.



## 💬 참고사항
> 기존 코드에서의 경고 메시지 
 ![Image](https://github.com/user-attachments/assets/d84a7d8f-6ee6-4775-b30f-d56828f71dd4)



## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
