### PR TITLE
BUG(auction_item)] 키워드 전체 조회 기능에서 카운트 쿼리에 where절 오류 등 수정

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemControllerV1.java
@@ -98,7 +98,8 @@ public class AuctionItemControllerV1 {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body((ApiResponse.success("해당 키워드를 가진 상품들이 모두 조회되었습니다.", searchKeywordAuctionItems)));
+            .body(
+                (ApiResponse.success("해당 키워드를 가진 경매 물품들이 모두 조회되었습니다.", searchKeywordAuctionItems)));
     }
 
     @PutMapping(value = "/{auctionItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -134,7 +134,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
 
         JPAQuery<Long> countQuery = queryFactory.select(auctionItem.count())
             .from(auctionItem)
-            .where(builder);
+            .where(auctionItem.isDeleted.eq(false), builder);
 
         List<SearchAuctionItemRes> content = query.fetch();
 


### PR DESCRIPTION
## 🔗 연관된 이슈
> close #72 



## 📝 요약
> 무엇을 했는지 요약

1. AuctionItemRepository 부분 where절 안에 isDeleted 추가 
2. Controller 부분 "상품" -> "경매 물품" 으로 수정하였습니다.

## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용



## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
