### PR TITLE
[Feature(user)] 사용자는 회원가입 또는 프로필 변경시 이미지를 설정할 수 있다

### DIFF
--- a/src/main/java/nbc/mushroom/config/AuthUserArgumentResolver.java
+++ b/src/main/java/nbc/mushroom/config/AuthUserArgumentResolver.java
@@ -42,8 +42,9 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
         Long userId = (Long) request.getAttribute("userId");
         String email = (String) request.getAttribute("email");
         String nickname = (String) request.getAttribute("nickname");
+        String imageUrl = (String) request.getAttribute("imageUrl");
         UserRole userRole = UserRole.of((String) request.getAttribute("userRole"));
 
-        return new AuthUser(userId, email, nickname, userRole);
+        return new AuthUser(userId, email, nickname, imageUrl, userRole);
     }
 }

--- a/src/main/java/nbc/mushroom/config/JwtFilter.java
+++ b/src/main/java/nbc/mushroom/config/JwtFilter.java
@@ -76,6 +76,7 @@ public class JwtFilter implements Filter {
             httpRequest.setAttribute("email", claims.get("email"));
             httpRequest.setAttribute("userRole", claims.get("userRole"));
             httpRequest.setAttribute("nickname", claims.get("nickname"));
+            httpRequest.setAttribute("imageUrl", claims.get("imageUrl"));
 
             chain.doFilter(request, response);
         } catch (SecurityException | MalformedJwtException e) {

--- a/src/main/java/nbc/mushroom/domain/auth/controller/AuthControllerV2.java
+++ b/src/main/java/nbc/mushroom/domain/auth/controller/AuthControllerV2.java
@@ -1,0 +1,32 @@
+package nbc.mushroom.domain.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.auth.dto.request.UserRegisterReq;
+import nbc.mushroom.domain.auth.dto.response.TokenRes;
+import nbc.mushroom.domain.auth.service.AuthService;
+import nbc.mushroom.domain.common.dto.ApiResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/auth")
+public class AuthControllerV2 {
+
+    private final AuthService authService;
+
+    @PostMapping(value = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<TokenRes>> register(
+        @Valid @ModelAttribute UserRegisterReq userRegisterReq
+    ) {
+        TokenRes tokenRes = authService.register(userRegisterReq);
+        return ResponseEntity.ok(
+            ApiResponse.success("정상적으로 회원가입 되었습니다.", tokenRes)
+        );
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/auth/dto/request/UserRegisterReq.java
+++ b/src/main/java/nbc/mushroom/domain/auth/dto/request/UserRegisterReq.java
@@ -3,6 +3,8 @@ package nbc.mushroom.domain.auth.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UserRegisterReq(
     @NotBlank
@@ -17,10 +19,17 @@ public record UserRegisterReq(
     String password,
 
     @NotBlank
+    @Pattern(
+        regexp = "^(?i)(admin|user)$", // (?i) 대소문자 구분 없이 허용
+        message = "userRole은 'admin' 또는 'user'만 가능합니다."
+    )
     String userRole,
 
     @NotBlank
-    String nickname
+    @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
+    String nickname,
+
+    MultipartFile image
 ) {
 
 }

--- a/src/main/java/nbc/mushroom/domain/auth/service/AuthService.java
+++ b/src/main/java/nbc/mushroom/domain/auth/service/AuthService.java
@@ -48,6 +48,7 @@ public class AuthService {
             savedUser.getId(),
             savedUser.getEmail(),
             savedUser.getNickname(),
+            savedUser.getImageUrl(),
             userRole
         );
 
@@ -66,6 +67,7 @@ public class AuthService {
             user.getId(),
             user.getEmail(),
             user.getNickname(),
+            user.getImageUrl(),
             user.getUserRole()
         );
 

--- a/src/main/java/nbc/mushroom/domain/auth/service/AuthService.java
+++ b/src/main/java/nbc/mushroom/domain/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import nbc.mushroom.domain.auth.dto.response.TokenRes;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.common.util.JwtUtil;
 import nbc.mushroom.domain.common.util.PasswordEncoder;
+import nbc.mushroom.domain.common.util.image.ImageUtil;
 import nbc.mushroom.domain.user.entity.User;
 import nbc.mushroom.domain.user.entity.UserRole;
 import nbc.mushroom.domain.user.repository.UserRepository;
@@ -25,6 +26,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final ImageUtil imageUtil;
 
     @Transactional
     public TokenRes register(UserRegisterReq userRegisterReq) {
@@ -35,12 +37,15 @@ public class AuthService {
         UserRole userRole = UserRole.of(userRegisterReq.userRole());
         String encodedPassword = passwordEncoder.encode(userRegisterReq.password());
 
+        String fileName = imageUtil.upload(userRegisterReq.image());
+
         User savedUser = userRepository.save(
             User.builder()
                 .email(userRegisterReq.email())
                 .password(encodedPassword)
                 .userRole(userRole)
                 .nickname(userRegisterReq.nickname())
+                .imageUrl(fileName)
                 .build()
         );
 
@@ -48,7 +53,7 @@ public class AuthService {
             savedUser.getId(),
             savedUser.getEmail(),
             savedUser.getNickname(),
-            savedUser.getImageUrl(),
+            imageUtil.getImageUrl(savedUser.getImageUrl()),
             userRole
         );
 
@@ -67,7 +72,7 @@ public class AuthService {
             user.getId(),
             user.getEmail(),
             user.getNickname(),
-            user.getImageUrl(),
+            imageUtil.getImageUrl(user.getImageUrl()),
             user.getUserRole()
         );
 

--- a/src/main/java/nbc/mushroom/domain/common/dto/AuthUser.java
+++ b/src/main/java/nbc/mushroom/domain/common/dto/AuthUser.java
@@ -2,6 +2,6 @@ package nbc.mushroom.domain.common.dto;
 
 import nbc.mushroom.domain.user.entity.UserRole;
 
-public record AuthUser(Long id, String email, String nickname, UserRole userRole) {
+public record AuthUser(Long id, String email, String nickname, String imageUrl, UserRole userRole) {
 
 }

--- a/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
@@ -22,7 +22,7 @@ import org.springframework.util.StringUtils;
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+    private static final long TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
 
     @Value("${jwt.secret.key}")
     private String secretKey;

--- a/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
@@ -35,7 +35,9 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, String nickname, UserRole userRole) {
+    public String createToken(
+        Long userId, String email, String nickname, String imageUrl, UserRole userRole
+    ) {
         Date date = new Date();
 
         return BEARER_PREFIX +
@@ -44,6 +46,7 @@ public class JwtUtil {
                 .claim("email", email)
                 .claim("nickname", nickname)
                 .claim("userRole", userRole)
+                .claim("imageUrl", imageUrl)
                 .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                 .setIssuedAt(date) // 발급일
                 .signWith(key, signatureAlgorithm) // 암호화 알고리즘

--- a/src/main/java/nbc/mushroom/domain/common/util/image/ImageUtilS3.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/image/ImageUtilS3.java
@@ -70,6 +70,9 @@ public class ImageUtilS3 implements ImageUtil {
 
     @Override
     public String getImageUrl(String filename) {
+        if (filename == null) {
+            return null;
+        }
         return endpoint + "/" + filename;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/common/util/image/ImageUtilS3.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/image/ImageUtilS3.java
@@ -56,6 +56,9 @@ public class ImageUtilS3 implements ImageUtil {
 
     @Override
     public void delete(String filename) {
+        if (filename == null) {
+            return;
+        }
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                 .bucket(bucketName)

--- a/src/main/java/nbc/mushroom/domain/user/controller/UserControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/user/controller/UserControllerV1.java
@@ -1,15 +1,20 @@
 package nbc.mushroom.domain.user.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.auth.dto.response.TokenRes;
 import nbc.mushroom.domain.common.annotation.Auth;
 import nbc.mushroom.domain.common.dto.ApiResponse;
 import nbc.mushroom.domain.common.dto.AuthUser;
+import nbc.mushroom.domain.user.dto.request.UserInfoChangeReq;
 import nbc.mushroom.domain.user.dto.request.UserPasswordChangeReq;
 import nbc.mushroom.domain.user.dto.response.UserRes;
 import nbc.mushroom.domain.user.service.UserService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,10 +36,22 @@ public class UserControllerV1 {
             .ok(ApiResponse.success("유저가 정상적으로 조회되었습니다.", userRes));
     }
 
-    @PutMapping
+    @PutMapping(value = "/info", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<TokenRes>> changeUserInfo(
+        @Auth AuthUser authUser,
+        @Valid @ModelAttribute UserInfoChangeReq userInfoChangeReq
+    ) {
+        TokenRes tokenRes = userService.changeInfo(authUser, userInfoChangeReq);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.success("유저의 정보가 정상적으로 변경되었습니다.", tokenRes));
+    }
+
+    @PutMapping("/password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
         @Auth AuthUser authUser,
-        @RequestBody UserPasswordChangeReq userPasswordChangeReq
+        @Valid @RequestBody UserPasswordChangeReq userPasswordChangeReq
     ) {
         userService.changePassword(authUser.id(), userPasswordChangeReq);
 

--- a/src/main/java/nbc/mushroom/domain/user/dto/request/UserInfoChangeReq.java
+++ b/src/main/java/nbc/mushroom/domain/user/dto/request/UserInfoChangeReq.java
@@ -1,0 +1,15 @@
+package nbc.mushroom.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+public record UserInfoChangeReq(
+    @NotBlank
+    @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
+    String nickname,
+
+    MultipartFile image
+) {
+
+}

--- a/src/main/java/nbc/mushroom/domain/user/dto/response/UserRes.java
+++ b/src/main/java/nbc/mushroom/domain/user/dto/response/UserRes.java
@@ -4,10 +4,12 @@ import nbc.mushroom.domain.user.entity.User;
 
 public record UserRes(
     Long id,
-    String email
+    String email,
+    String nickname,
+    String imageUrl
 ) {
 
     public static UserRes from(User user) {
-        return new UserRes(user.getId(), user.getEmail());
+        return new UserRes(user.getId(), user.getEmail(), user.getNickname(), user.getImageUrl());
     }
 }

--- a/src/main/java/nbc/mushroom/domain/user/entity/User.java
+++ b/src/main/java/nbc/mushroom/domain/user/entity/User.java
@@ -67,5 +67,12 @@ public class User extends Timestamped {
     public void changePassword(String password) {
         this.password = password;
     }
+
+    public void updateInfo(String nickname, String imageUrl) {
+        if (imageUrl != null) {
+            this.imageUrl = imageUrl;
+        }
+        this.nickname = nickname;
+    }
 }
 

--- a/src/main/java/nbc/mushroom/domain/user/entity/User.java
+++ b/src/main/java/nbc/mushroom/domain/user/entity/User.java
@@ -45,11 +45,13 @@ public class User extends Timestamped {
     private UserRole userRole;
 
     @Builder
-    public User(Long id, String email, String password, String nickname, UserRole userRole) {
+    public User(Long id, String email, String password, String nickname, String imageUrl,
+        UserRole userRole) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
+        this.imageUrl = imageUrl;
         this.userRole = userRole;
     }
 
@@ -57,16 +59,13 @@ public class User extends Timestamped {
         return User.builder()
             .id(authUser.id())
             .email(authUser.email())
+            .imageUrl(authUser.imageUrl())
             .userRole(authUser.userRole())
             .build();
     }
 
     public void changePassword(String password) {
         this.password = password;
-    }
-
-    public void updateRole(UserRole userRole) {
-        this.userRole = userRole;
     }
 }
 

--- a/src/main/java/nbc/mushroom/domain/user/entity/User.java
+++ b/src/main/java/nbc/mushroom/domain/user/entity/User.java
@@ -59,7 +59,6 @@ public class User extends Timestamped {
         return User.builder()
             .id(authUser.id())
             .email(authUser.email())
-            .imageUrl(authUser.imageUrl())
             .userRole(authUser.userRole())
             .build();
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
> close #77 


## 📝 요약
> 무엇을 했는지 요약

- 회원가입 할 때 이미지 추가 가능
- 프로필 이미지 변경 기능
- JWT 토큰 기간 7일로 늘림


## 💬 참고사항
> 고민했던 부분이나, 이해를 위해 참고할 내용

사용자가 프로필을 수정할 때 DB에서만 반영하면 안된다는 것을 알았습니다.

왜냐하면 클라이언트(브라우저)는 이전에 보내줬던 토큰을 계속 가지고 있고, 이 토큰안의 정보는 변경되지 않으니깐요

따라서 프로필 변경시 토큰 새로 생성하도록 구현했습니다.


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
