### PR TITLE
[Feature(auction_item)] 인기 검색어 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,10 +56,13 @@ dependencies {
     implementation 'at.favre.lib:bcrypt:0.10.2'
 
     // spring-cache
-    // implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // redis
-    // implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // AWS
     implementation platform('software.amazon.awssdk:bom:2.20.114')
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sqs'

--- a/src/main/java/nbc/mushroom/config/CacheConfig.java
+++ b/src/main/java/nbc/mushroom/config/CacheConfig.java
@@ -16,7 +16,7 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
         cacheManager.setCaffeine(
-            Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.DAYS).recordStats());
+            Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).recordStats());
         return cacheManager;
     }
 }

--- a/src/main/java/nbc/mushroom/config/CacheConfig.java
+++ b/src/main/java/nbc/mushroom/config/CacheConfig.java
@@ -1,0 +1,22 @@
+package nbc.mushroom.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(
+            Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.DAYS).recordStats());
+        return cacheManager;
+    }
+}

--- a/src/main/java/nbc/mushroom/config/WebConfig.java
+++ b/src/main/java/nbc/mushroom/config/WebConfig.java
@@ -8,7 +8,6 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-// @EnableCaching // 인기 검색어 캐싱 시 사용 예정
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {

--- a/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemControllerV1.java
@@ -2,7 +2,9 @@ package nbc.mushroom.domain.auction_item.controller;
 
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.auction_item.dto.request.CreateAuctionItemReq;
 import nbc.mushroom.domain.auction_item.dto.request.PutAuctionItemReq;
 import nbc.mushroom.domain.auction_item.dto.response.AuctionItemRes;
@@ -31,6 +33,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auction-items")
@@ -38,6 +41,7 @@ public class AuctionItemControllerV1 {
 
     private final AuctionItemService auctionItemService;
 
+    // 경매 물품 생성
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AuctionItemRes>> postAuctionItem(
         @Valid @ModelAttribute CreateAuctionItemReq createAuctionItemReq,
@@ -91,6 +95,7 @@ public class AuctionItemControllerV1 {
         @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime endDate,
         @RequestParam(value = "minPrice", required = false) Long minPrice,
         @RequestParam(value = "maxPrice", required = false) Long maxPrice) {
+
         Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(sort, sortOrder));
         Page<SearchAuctionItemRes> searchKeywordAuctionItems = auctionItemService.searchKeywordAuctionItems(
             sort, sortOrder, keyword, brand, category, size, startDate, endDate, minPrice,
@@ -102,6 +107,7 @@ public class AuctionItemControllerV1 {
                 (ApiResponse.success("해당 키워드를 가진 경매 물품들이 모두 조회되었습니다.", searchKeywordAuctionItems)));
     }
 
+    // 경매 물품 수정
     @PutMapping(value = "/{auctionItemId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<AuctionItemRes>> putAuctionItem(
         @ModelAttribute PutAuctionItemReq putAuctionItemReq,
@@ -116,6 +122,7 @@ public class AuctionItemControllerV1 {
             .body(ApiResponse.success("경매 물품 수정에 성공했습니다.", auctionItemRes));
     }
 
+    // 경매 물품 삭제
     @DeleteMapping(value = "/{auctionItemId}")
     public ResponseEntity<ApiResponse<Void>> deleteAuctionItem(
         @PathVariable Long auctionItemId,
@@ -129,16 +136,20 @@ public class AuctionItemControllerV1 {
             .body(ApiResponse.success("경매 물품 삭제에 성공했습니다."));
     }
 
-//    // 인기 검색어 조회 -> 차순위 개발로 주석처리
-//    @GetMapping("/popular-keywords")
-//    public ResponseEntity<ApiResponse<List<String>>> getPopularKeywords() {
-//        List<String> keywords = auctionItemService.getPopularKeywords();
-//        return ResponseEntity.ok(ApiResponse.success("인기 검색어 조회에 성공했습니다.", keywords));
-//    }
-//
-//    // 저장된 캐시 내용 확인하는 API -> 인메모리 캐싱은 캐시 저장소에 데이터가 저장된 것을 확인하지 못하기 때문
-//    @GetMapping("/{storedCache}")
-//    public void printCache(@PathVariable String storedCache) {
-//        auctionItemService.printCacheContents(storedCache);
-//    }
+    // 인기 검색어 조회 TODO 반환방식 통일하기!
+    @GetMapping("/popular-keywords")
+    public ResponseEntity<ApiResponse<List<String>>> getPopularKeywords() {
+
+        List<String> popularKeywords = auctionItemService.searchPopularKeywords();
+
+        return ResponseEntity.ok(
+            ApiResponse.success("인기 검색어 조회에 성공했습니다.", popularKeywords));
+    }
+
+    // 캐시 내용 가시화 API
+    @GetMapping("/popular-keywords/cache")
+    public ResponseEntity<ApiResponse<Void>> printCache() {
+        auctionItemService.printPopularKeywordsCacheContents();
+        return ResponseEntity.ok(ApiResponse.success("인기 검색어 캐시 내용이 로그에 출력되었습니다."));
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -315,6 +315,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
         if (size != null) {
             builder.and(auctionItem.size.eq(size));
         }
+
         if (startDate != null) {
             builder.and(auctionItem.startTime.goe(startDate));
         }

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -12,7 +12,6 @@ import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.repository.AuctionItemRepository;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +23,7 @@ public class AuctionItemStatusService {
     private final AuctionItemRepository auctionItemRepository;
     private final BidRepository bidRepository;
 
-    @Scheduled(cron = "0 */1 * * * *") // 매 5분마다 (정각 기준)
+    //    @Scheduled(cron = "0 */1 * * * *") // 매 5분마다 (정각 기준)
     @Transactional(readOnly = false)
     public void startAuctions() {
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES); // 초 단위 버림
@@ -41,7 +40,7 @@ public class AuctionItemStatusService {
         }
     }
 
-    @Scheduled(cron = "0 */1 * * * *") // 매 5분마다 (정각 기준)
+    //    @Scheduled(cron = "0 */1 * * * *") // 매 5분마다 (정각 기준)
     @Transactional(readOnly = false)
     public void completeAuctions() {
         LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES); // 초 단위 버림


### PR DESCRIPTION
## 🔗 연관된 이슈
> close #31 



## 📝 요약
> Cacheable + CaffeineCacheManager 방식을 사용해 로컬 메모리 캐싱을 적용한 인기 검색어를 조회할 수 있습니다. 인메모리 캐싱의 특성상, 캐시 저장소에 실제로 캐싱이 되어있는지 확인 할 방법이 없어 테스트 시에 편리하게 내역을 확인할 수 있도록 캐시내역 가시화 로직도 추가 해놨습니다. 검색된 적이 없던 검색어는 인기 검색어 조회 시에 나오지 않도록 하였고, top10 의 검색어만 조회되도록 limit을 걸어놨습니다. 
또한, 개발을 하는 동안 제가 써야하는 메서드를 찾기가 어려워서, 주석을 달아놨는데 푸쉬할 때 지우는 걸 깜빡했습니다! 추후에 필요없는 내용은 삭제하도록 하겠습니다. 


## 💬 참고사항
> 
캐시 가시화 API 사용 시 예시 로그
![image](https://github.com/user-attachments/assets/34e6c659-b7d4-47fe-b5a2-1f9ba46ea457)

TEST 시 엔드포인트 형식, 예시 응답
![image](https://github.com/user-attachments/assets/2f496a30-ad34-47d1-be0b-22a71b1d0732)


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
