### PR TITLE
[Bug(admin)] 해당 api만 page가 0부터 조회되는 것 변경

### DIFF
--- a/src/main/java/nbc/mushroom/domain/admin/controller/AuctionItemAdminControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/admin/controller/AuctionItemAdminControllerV1.java
@@ -1,7 +1,9 @@
 package nbc.mushroom.domain.admin.controller;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.admin.dto.request.AuctionItemChangeStatusReq;
 import nbc.mushroom.domain.admin.dto.response.AuctionItemStatusRes;
 import nbc.mushroom.domain.admin.service.AuctionItemAdminService;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
@@ -13,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,27 +27,13 @@ public class AuctionItemAdminControllerV1 {
 
     private final AuctionItemAdminService auctionItemAdminService;
 
-    // 물품 검수 합격 -> status 대기중 (waiting)
-    @PatchMapping("/{auctionItemId}/approve")
+    @PatchMapping("/{auctionItemId}")
     public ResponseEntity<ApiResponse<Void>> adminApproveAuctionItem(
-        @PathVariable Long auctionItemId) {
-
-        auctionItemAdminService.approveAuctionItem(auctionItemId);
-
-        return ResponseEntity.ok(
-            ApiResponse.success("관리자가 경매 물품을 승인했습니다.")
-        );
-    }
-
-    @PatchMapping("/{auctionItemId}/reject")
-    public ResponseEntity<ApiResponse<Void>> adminRejectAuctionItem(
-        @PathVariable Long auctionItemId) {
-
-        auctionItemAdminService.rejectAuctionItem(auctionItemId);
-
-        return ResponseEntity.ok(
-            ApiResponse.success("관리자가 경매 물품을 반려했습니다.")
-        );
+        @PathVariable Long auctionItemId,
+        @Valid @RequestBody AuctionItemChangeStatusReq auctionItemChangeStatusReq
+    ) {
+        auctionItemAdminService.changeStatusAuctionItem(auctionItemId, auctionItemChangeStatusReq);
+        return ResponseEntity.ok(ApiResponse.success("물품 검수가 완료되었습니다."));
     }
 
     // 관리자 경매 물품 상태 목록 전체 조회 + 필터링 조회 기능 API

--- a/src/main/java/nbc/mushroom/domain/admin/controller/AuctionItemAdminControllerV1.java
+++ b/src/main/java/nbc/mushroom/domain/admin/controller/AuctionItemAdminControllerV1.java
@@ -7,6 +7,7 @@ import nbc.mushroom.domain.admin.service.AuctionItemAdminService;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
 import nbc.mushroom.domain.common.dto.ApiResponse;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,12 +50,14 @@ public class AuctionItemAdminControllerV1 {
     // 관리자 경매 물품 상태 목록 전체 조회 + 필터링 조회 기능 API
     @GetMapping
     public ResponseEntity<ApiResponse<Page<AuctionItemStatusRes>>> adminSearchAuctionItemsStatus(
-        @RequestParam(required = false) List<AuctionItemStatus> status, Pageable pageable) {
-
-        Page<AuctionItemStatusRes> auctionItemsStatus = auctionItemAdminService.getAuctionItemsStatus(
-            status, pageable);
+        @RequestParam(required = false) List<AuctionItemStatus> status,
+        @RequestParam(value = "page", defaultValue = "1") int page
+    ) {
+        Pageable pageable = PageRequest.of(page - 1, 10);
+        Page<AuctionItemStatusRes> auctionItemsStatusRes = auctionItemAdminService
+            .getAuctionItemsStatus(status, pageable);
 
         return ResponseEntity.ok(
-            ApiResponse.success("경매 물품 상태 목록을 조회했습니다.", auctionItemsStatus));
+            ApiResponse.success("경매 물품 상태 목록을 조회했습니다.", auctionItemsStatusRes));
     }
 }

--- a/src/main/java/nbc/mushroom/domain/admin/dto/request/AuctionItemChangeStatusReq.java
+++ b/src/main/java/nbc/mushroom/domain/admin/dto/request/AuctionItemChangeStatusReq.java
@@ -1,0 +1,16 @@
+package nbc.mushroom.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record AuctionItemChangeStatusReq(
+    @NotBlank
+    @Pattern(
+        regexp = "^(?i)(approve|reject)$", // (?i) 대소문자 구분 없이 허용
+        message = "action은 'approve' 또는 'reject'만 가능합니다."
+    )
+    String action
+) {
+
+}
+

--- a/src/main/java/nbc/mushroom/domain/admin/service/AuctionItemAdminService.java
+++ b/src/main/java/nbc/mushroom/domain/admin/service/AuctionItemAdminService.java
@@ -39,13 +39,10 @@ public class AuctionItemAdminService {
 
     // 관리자 경매 물품 상태 목록 전체 조회 + 상태별 필터링 조회
     @Transactional(readOnly = true)
-    public Page<AuctionItemStatusRes> getAuctionItemsStatus(List<AuctionItemStatus> status,
-        Pageable pageable) {
-
-        if (status != null && !status.isEmpty()) {
-            return auctionItemRepository.findAuctionItemsByStatus(status, pageable);
-        } else {
-            return auctionItemRepository.findAllAuctionItemsByStatus(pageable);
-        }
+    public Page<AuctionItemStatusRes> getAuctionItemsStatus(
+        List<AuctionItemStatus> status,
+        Pageable pageable
+    ) {
+        return auctionItemRepository.findAuctionItemsByStatus(status, pageable);
     }
 }

--- a/src/main/java/nbc/mushroom/domain/admin/service/AuctionItemAdminService.java
+++ b/src/main/java/nbc/mushroom/domain/admin/service/AuctionItemAdminService.java
@@ -3,6 +3,7 @@ package nbc.mushroom.domain.admin.service;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import nbc.mushroom.domain.admin.dto.request.AuctionItemChangeStatusReq;
 import nbc.mushroom.domain.admin.dto.response.AuctionItemStatusRes;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
@@ -19,21 +20,18 @@ public class AuctionItemAdminService {
 
     private final AuctionItemRepository auctionItemRepository;
 
-    // 경매 물품 검수 합격 -> status 대기중 (waiting)
+    // 경매 물품 검수
     @Transactional
-    public void approveAuctionItem(Long auctionItemId) {
-
+    public void changeStatusAuctionItem(
+        Long auctionItemId,
+        AuctionItemChangeStatusReq auctionItemChangeStatusReq
+    ) {
         AuctionItem auctionItem = auctionItemRepository.findAuctionItemById(auctionItemId);
 
-        auctionItem.approve();
-    }
-
-    // 경매 물품 검수 불합격 -> status 실패 (rejected)
-    @Transactional
-    public void rejectAuctionItem(Long auctionItemId) {
-
-        AuctionItem auctionItem = auctionItemRepository.findAuctionItemById(auctionItemId);
-
+        if (auctionItemChangeStatusReq.action().equalsIgnoreCase("approve")) {
+            auctionItem.approve();
+            return;
+        }
         auctionItem.reject();
     }
 

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
@@ -36,7 +36,4 @@ public interface AuctionItemRepositoryCustom {
     // 경매 물품 상태별 필터링 조회
     Page<AuctionItemStatusRes> findAuctionItemsByStatus(
         List<AuctionItemStatus> status, Pageable pageable);
-
-    // 경매 물품 상태 목록 전체 조회
-    Page<AuctionItemStatusRes> findAllAuctionItemsByStatus(Pageable pageable);
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -189,11 +189,11 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
 
     // 경매 물품 상태별 목록 필터링 조회 메서드
     @Override
-    public Page<AuctionItemStatusRes> findAuctionItemsByStatus(List<AuctionItemStatus> status,
-        Pageable pageable) {
-
+    public Page<AuctionItemStatusRes> findAuctionItemsByStatus(
+        List<AuctionItemStatus> status,
+        Pageable pageable
+    ) {
         QAuctionItem auctionItem = QAuctionItem.auctionItem;
-
         BooleanBuilder builder = new BooleanBuilder();
 
         if (status != null && !status.isEmpty()) {
@@ -216,6 +216,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             ))
             .from(auctionItem)
             .where(builder)
+            .orderBy(auctionItem.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
@@ -224,36 +225,6 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             .select(auctionItem.count())
             .from(auctionItem)
             .where(builder);
-
-        return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
-    }
-
-    // 경매 물품 상태 목록 전체 조회 메서드
-    @Override
-    public Page<AuctionItemStatusRes> findAllAuctionItemsByStatus(Pageable pageable) {
-
-        List<AuctionItemStatusRes> results = queryFactory
-            .select(new QAuctionItemStatusRes(
-                auctionItem.id,
-                auctionItem.name,
-                auctionItem.description,
-                auctionItem.imageUrl,
-                auctionItem.size,
-                auctionItem.category,
-                auctionItem.brand,
-                auctionItem.startPrice,
-                auctionItem.startTime,
-                auctionItem.endTime,
-                auctionItem.status
-            ))
-            .from(auctionItem)
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
-
-        JPAQuery<Long> total = queryFactory
-            .select(auctionItem.count())
-            .from(auctionItem);
 
         return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
     }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -193,12 +193,13 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
         List<AuctionItemStatus> status,
         Pageable pageable
     ) {
+        if (status == null || status.isEmpty()) {
+            return Page.empty(pageable);
+        }
+
         QAuctionItem auctionItem = QAuctionItem.auctionItem;
         BooleanBuilder builder = new BooleanBuilder();
-
-        if (status != null && !status.isEmpty()) {
-            builder.and(auctionItem.status.in(status));
-        }
+        builder.and(auctionItem.status.in(status));
 
         List<AuctionItemStatusRes> results = queryFactory
             .select(new QAuctionItemStatusRes(
@@ -215,7 +216,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
                 auctionItem.status
             ))
             .from(auctionItem)
-            .where(builder)
+            .where(auctionItem.isDeleted.eq(false), builder)
             .orderBy(auctionItem.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
@@ -224,7 +225,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
         JPAQuery<Long> total = queryFactory
             .select(auctionItem.count())
             .from(auctionItem)
-            .where(builder);
+            .where(auctionItem.isDeleted.eq(false), builder);
 
         return PageableExecutionUtils.getPage(results, pageable, total::fetchOne);
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
> close #83 



## 📝 요약
> 무엇을 했는지 요약

- 페이지가 0부터 시작하는 것을 1부터 시작하도록 변경했습니다.
- 생성일 기준 역순으로 조회하는 것이 보기 좋아서 추가했습니다.
- PATCH로 상태를 변경하는 부분에서 하나의 api로 관리하는게 더 좋을 것 같아서 합쳤습니다.
- status가 하나도 없으면 그냥 아무것도 반환 안되도록 하고, isDeleted 처리 추가했습니다.


## 💬 참고사항

<img width="801" alt="스크린샷 2025-02-20 오후 3 55 47" src="https://github.com/user-attachments/assets/017b4a90-9480-4cff-86d3-b2f55b8ab91c" />

findAuctionItemByStatus에서 이미 status에 값이 있는지 확인을 하는데

<img width="759" alt="스크린샷 2025-02-20 오후 3 56 02" src="https://github.com/user-attachments/assets/6a879cc4-9f1c-47f8-bd54-f479610cbd1b" />

service계층에서 이 둘을 한 번 더 구분하여 repository 함수가 동일한게 하나 더 있어서 지우는 게 좋을 것 같다고 판단해서 확인 후에 제거했습니다. [`0843e576`](https://github.com/mushroom-4/mushroom-be/commit/0843e576032a7f6f7f80abdb4ba8aff32ab887dc)

큼큼.. 마음대로 지워서 감사합니다


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
