### PR TITLE
[Feature(chat)] 현재 최고 입찰가 알림 메시지 전송 구현

### DIFF
--- a/src/main/java/nbc/mushroom/config/websocket/RedisChatConfig.java
+++ b/src/main/java/nbc/mushroom/config/websocket/RedisChatConfig.java
@@ -3,7 +3,7 @@ package nbc.mushroom.config.websocket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import nbc.mushroom.domain.chat.entity.ChatMessage;
+import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
 import nbc.mushroom.domain.chat.service.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -53,8 +53,8 @@ public class RedisChatConfig {
         objectMapper.enable(
             SerializationFeature.INDENT_OUTPUT); // 읽기 쉽게 들여쓰기 활성화 (디버깅 용도, 베포 시엔 성능을 위해 비활성화)
 
-        Jackson2JsonRedisSerializer<ChatMessage> serializer = new Jackson2JsonRedisSerializer<>(
-            objectMapper, ChatMessage.class);
+        Jackson2JsonRedisSerializer<ChatMessageRes> serializer = new Jackson2JsonRedisSerializer<>(
+            objectMapper, ChatMessageRes.class);
 
         redisTemplate.setValueSerializer(serializer); // value 직렬화 설정
 

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -16,6 +16,7 @@ import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
 import nbc.mushroom.domain.bid.dto.response.CreateBidRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
+import nbc.mushroom.domain.chat.service.ChatService;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class BidService {
 
     private final BidRepository bidRepository;
     private final AuctionItemRepository auctionItemRepository;
+    private final ChatService chatService;
 
     @Transactional(readOnly = false)
     public CreateBidRes createOrUpdateBid(
@@ -48,6 +50,9 @@ public class BidService {
         if (!createBidReq.biddingPrice().equals(findBid.getBiddingPrice())) {
             findBid.updateBiddingPrice(createBidReq.biddingPrice());
         }
+
+        chatService.sendBidAnnouncementMessage(findAuctionItem.getId(), findBid.getBidder(),
+            findBid.getBiddingPrice());
 
         return CreateBidRes.from(findBid);
     }

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -42,23 +42,24 @@ public class ChatService {
 
         log.info("ChatMessaeg 객체 생성 [ChatRoomId : {}] [SenderId : {}]", chatRoomId, chatMessage);
 
-        saveChatMessage(chatRoomId, chatMessage);
+        ChatMessageRes chatMessageRes = ChatMessageRes.from(chatMessage);
+        saveChatMessage(chatRoomId, chatMessageRes);
 
-        redisPublish.publish(chatMessage);
+        redisPublish.publish(chatMessageRes);
 
-        return ChatMessageRes.from(chatMessage);
+        return chatMessageRes;
     }
 
     /**
      * Redis에 채팅 저장
      *
      * @param chatRoomId     채팅방 ID
-     * @param chatMessage 저장할 메시지 객체
+     * @param chatMessageRes 저장할 메시지 객체
      */
-    public void saveChatMessage(Long chatRoomId, ChatMessage chatMessage) {
+    public void saveChatMessage(Long chatRoomId, ChatMessageRes chatMessageRes) {
         String key = REDIS_CHAT_ROOM_KEY + chatRoomId;
         log.info("Redis Storage [Key : {}]", key);
-        redisTemplate.opsForList().rightPush(key, chatMessage); // key - value
+        redisTemplate.opsForList().rightPush(key, chatMessageRes); // key - value
     }
 
 
@@ -80,8 +81,7 @@ public class ChatService {
         }
 
         return chatMessageList.stream()
-            .map(o -> (ChatMessage) o) // Object → ChatMessage 변환
-            .map(ChatMessageRes::from) // ChatMessage → ChatMessageRes 변환
+            .map(o -> (ChatMessageRes) o) // Object → ChatMessage 변환
             .toList(); // 최종 List<ChatMessageRes> 반환
     }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -50,6 +50,26 @@ public class ChatService {
         return chatMessageRes;
     }
 
+    public void sendBidAnnouncementMessage(Long chatRoomId, User bidder,
+        Long bidiingPrice) {
+        String message = bidiingPrice + "원에 입찰하였습니다. ";
+        ChatMessage announcementMessage = ChatMessage.builder()
+            .chatRoomId(chatRoomId)
+            .messageType(MessageType.ANNOUNCEMENT)
+            .message(message)
+            .sender(bidder)
+            .sendDateTime(LocalDateTime.now())
+            .build();
+
+        log.info("AnnouncementMessaeg 객체 생성 [ChatRoomId : {}] [SenderId : {}]", chatRoomId,
+            announcementMessage);
+
+        ChatMessageRes announcementMessageRes = ChatMessageRes.from(announcementMessage);
+        saveChatMessage(chatRoomId, announcementMessageRes);
+
+        redisPublish.publish(announcementMessageRes);
+    }
+
     /**
      * Redis에 채팅 저장
      *

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisPublish.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisPublish.java
@@ -1,7 +1,7 @@
 package nbc.mushroom.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
-import nbc.mushroom.domain.chat.entity.ChatMessage;
+import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Service;
@@ -19,9 +19,9 @@ public class RedisPublish {
      * ChatMessageRes 객체를 Redis 채널에 전송
      * 해당 채널의 모든 구독자(클라이언트)에게 메시지를 브로드캐스트
      *
-     * @param chatMessage : 메시지 정보
+     * @param chatMessageRes : 메시지 정보
      */
-    public void publish(ChatMessage chatMessage) {
-        redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessage);
+    public void publish(ChatMessageRes chatMessageRes) {
+        redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessageRes);
     }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
@@ -1,10 +1,8 @@
 package nbc.mushroom.domain.chat.service;
 
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
-import nbc.mushroom.domain.chat.entity.ChatMessage;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -30,10 +28,8 @@ public class RedisSubscriber implements MessageListener {
      */
     @Override
     public void onMessage(Message message, byte[] pattern) {
-        ChatMessage chatMessage = (ChatMessage) redisTemplate.getValueSerializer()
+        ChatMessageRes chatMessageRes = (ChatMessageRes) redisTemplate.getValueSerializer()
             .deserialize(message.getBody());
-
-        ChatMessageRes chatMessageRes = ChatMessageRes.from(Objects.requireNonNull(chatMessage));
 
         log.info("[ChatRoomId: {}] [{}] {}: {} ( {} )",
             chatMessageRes.chatRoomId(),


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #88

## 📝 요약

> 무엇을 했는지 요약

- 유저가 입찰을 할 때마다 채팅방에 알림메시지를 전송하도록 구현했습니다. 
- Jackson이 ChatMessage 엔티티의 sender 필드(User 타입)를 직렬화할 때, Hibernate가 생성한 lazy 로딩 프록시을 직렬화할 수 없다는 문제가 발생하여, 직렬화 타입을 ChatMessageRes.class에서 ChatMessage.class로 수정하였습니다.

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

- 일반적으로 Hibernate는 연관관계 필드를 lazy 로딩 방식으로 처리할 때 프록시 객체를 반환하는데, 이 객체는 실제 엔티티의 속성을 가지고 있지 않거나, “hibernateLazyInitializer” 같은 내부 속성이 포함되어 있어서 Jackson이 이를 직렬화하지 못한다고 합니다.
<img width="317" alt="image" src="https://github.com/user-attachments/assets/4e91d1e6-d676-46b6-aed2-6e16ec0f9ba7" />

- 실행 사진
![image](https://github.com/user-attachments/assets/7dbd5623-c0b9-49f6-940e-f250942c6d3f)


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
