### PR TITLE
[Feature(review)] 특정 판매자에 대한 리뷰 삭제 기능 구현

### DIFF
--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -68,7 +68,7 @@ public enum ExceptionType {
     // Review
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "R01", "해당 판매자에 대한 리뷰를 이미 작성하였습니다."),
     BID_NO_PAYMENT(HttpStatus.BAD_REQUEST, "R02", "리뷰 작성 권한이 없습니다. 해당 경매 물품에 대한 결제 내역이 필요합니다."),
-    INVALID_REVIEW_USER(HttpStatus.FORBIDDEN, "R03", "본인이 구매한 물품에 한하여 리뷰 작성이 가능합니다."),
+    INVALID_REVIEW_USER(HttpStatus.FORBIDDEN, "R03", "본인이 구매한 물품에 한하여 리뷰 작성|삭제가 가능합니다."),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R04", "삭제 가능한 리뷰가 존재하지 않습니다."),
 
     ;

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -69,6 +69,7 @@ public enum ExceptionType {
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "R01", "해당 판매자에 대한 리뷰를 이미 작성하였습니다."),
     BID_NO_PAYMENT(HttpStatus.BAD_REQUEST, "R02", "리뷰 작성 권한이 없습니다. 해당 경매 물품에 대한 결제 내역이 필요합니다."),
     INVALID_REVIEW_USER(HttpStatus.FORBIDDEN, "R03", "본인이 구매한 물품에 한하여 리뷰 작성이 가능합니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R04", "삭제 가능한 리뷰가 존재하지 않습니다."),
 
     ;
 

--- a/src/main/java/nbc/mushroom/domain/review/controller/ReviewController.java
+++ b/src/main/java/nbc/mushroom/domain/review/controller/ReviewController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,10 +28,10 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @PostMapping("/bids/{bidId}/reviews")
+    @PostMapping("/bids/reviews")
     public ResponseEntity<ApiResponse<CreateSellerReviewRes>> createReview(
         @Auth AuthUser authUser,
-        @PathVariable Long bidId,
+        @RequestParam Long bidId,
         @Valid @RequestBody CreateSellerReviewReq createSellerReviewReq
     ) {
         CreateSellerReviewRes createSellerReviewRes = reviewService.createReview(
@@ -43,7 +44,7 @@ public class ReviewController {
 
     }
 
-    @GetMapping("/users/{sellerId}/reviews")
+    @GetMapping("/sellers/{sellerId}/reviews")
     public ResponseEntity<ApiResponse<SearchSellerReviewRes>> searchReviews(
         @PathVariable Long sellerId
     ) {
@@ -53,12 +54,12 @@ public class ReviewController {
             .body(ApiResponse.success("판매자 리뷰 조회가 성공적으로 이루어졌습니다.", searchSellerRes));
     }
 
-    @DeleteMapping("/bids/{bidId}/reviews/{reviewId}")
+    @DeleteMapping("/bids/reviews/{reviewId}")
     public ResponseEntity<ApiResponse<Void>> deleteReview(
         @Auth AuthUser authUser,
-        @PathVariable Long bidId
+        @PathVariable Long reviewId
     ) {
-        reviewService.deleteReview(User.fromAuthUser(authUser), bidId);
+        reviewService.deleteReview(User.fromAuthUser(authUser), reviewId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .body(ApiResponse.success("리뷰가 정상적으로 삭제 되었습니다."));

--- a/src/main/java/nbc/mushroom/domain/review/controller/ReviewController.java
+++ b/src/main/java/nbc/mushroom/domain/review/controller/ReviewController.java
@@ -53,7 +53,7 @@ public class ReviewController {
             .body(ApiResponse.success("판매자 리뷰 조회가 성공적으로 이루어졌습니다.", searchSellerRes));
     }
 
-    @DeleteMapping("/bids/{bidId}/reviews")
+    @DeleteMapping("/bids/{bidId}/reviews/{reviewId}")
     public ResponseEntity<ApiResponse<Void>> deleteReview(
         @Auth AuthUser authUser,
         @PathVariable Long bidId

--- a/src/main/java/nbc/mushroom/domain/review/controller/ReviewController.java
+++ b/src/main/java/nbc/mushroom/domain/review/controller/ReviewController.java
@@ -12,6 +12,7 @@ import nbc.mushroom.domain.review.service.ReviewService;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -51,5 +52,17 @@ public class ReviewController {
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse.success("판매자 리뷰 조회가 성공적으로 이루어졌습니다.", searchSellerRes));
     }
+
+    @DeleteMapping("/bids/{bidId}/reviews")
+    public ResponseEntity<ApiResponse<Void>> deleteReview(
+        @Auth AuthUser authUser,
+        @PathVariable Long bidId
+    ) {
+        reviewService.deleteReview(User.fromAuthUser(authUser), bidId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+            .body(ApiResponse.success("리뷰가 정상적으로 삭제 되었습니다."));
+    }
+
 }
 

--- a/src/main/java/nbc/mushroom/domain/review/dto/response/SearchSellerReviewDetailRes.java
+++ b/src/main/java/nbc/mushroom/domain/review/dto/response/SearchSellerReviewDetailRes.java
@@ -6,6 +6,7 @@ import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.review.entity.Review;
 
 public record SearchSellerReviewDetailRes(
+    Long reviewId,
     String content,
     int score,
     BidRes bid
@@ -13,7 +14,7 @@ public record SearchSellerReviewDetailRes(
 
     public static SearchSellerReviewDetailRes from(Review review) {
         return new SearchSellerReviewDetailRes(
-            review.getContent(), review.getScore(), new BidRes(review.getBid()));
+            review.getId(), review.getContent(), review.getScore(), new BidRes(review.getBid()));
     }
 
     @NoArgsConstructor

--- a/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepository.java
@@ -1,5 +1,7 @@
 package nbc.mushroom.domain.review.repository;
 
+import java.util.List;
+import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +9,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
     Boolean existsByBidId(Long bidId);
 
+    List<Review> bid(Bid bid);
 }

--- a/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryCustom.java
@@ -7,4 +7,5 @@ public interface ReviewRepositoryCustom {
 
     List<Review> findAllBySellerId(Long sellerId);
 
+    Review findByBidIdAndUserId(Long bidId, Long id);
 }

--- a/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryImpl.java
@@ -26,4 +26,14 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             .fetch();
     }
 
+    @Override
+    public Review findByBidIdAndUserId(Long bidId, Long id) {
+        return queryFactory
+            .selectFrom(review)
+            .innerJoin(review.bid, bid)
+            .where(bid.id.eq(bidId)
+                .and(bid.bidder.id.eq(id)))
+            .fetchOne();
+    }
+
 }

--- a/src/main/java/nbc/mushroom/domain/review/service/ReviewService.java
+++ b/src/main/java/nbc/mushroom/domain/review/service/ReviewService.java
@@ -80,5 +80,19 @@ public class ReviewService {
         // 평균 점수와 리뷰 세부정보를 포함한 결과 반환
         return new SearchSellerReviewRes(averageScore, reviewDetails);
     }
+
+    // 리뷰 삭제
+    @Transactional
+    public void deleteReview(User user, Long bidId) {
+
+        Review review = reviewRepository.findByBidIdAndUserId(bidId, user.getId());
+
+        if (review == null) {
+            throw new CustomException(ExceptionType.REVIEW_NOT_FOUND);
+        }
+
+        reviewRepository.delete(review);
+        //소프트딜리트와 고민하였는데, 리뷰같은 경우는 소프트 사용이 애매한 것 같아서 하드로 작성하였습니다.
+    }
 }
 


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #100 

## 📝 요약

> 결제를 완료하여 리뷰를 생성한 입찰자가 해당 리뷰를 삭제할 수 있도록 기능을 구현하였습니다.

## 💬 참고사항

> 공지같이 정보를 담는 것과 달리,
   리뷰의 경우 해당 작성자가 삭제를 한다면 굳이 소프트딜리트로 삭제한 리뷰를 가지고 있을 이유가 있을까? 생각하여 
   하드딜리트를 선택하였습니다.

   또한 삭제의 경우에도 생성과 같이 bids를 타고 들어가 식별하는 로직을 가지므로 "/bids/{bidId}/reviews/{reviewId}"로 
   엔드포인드를 정해보았습니다.
   
![image (27)](https://github.com/user-attachments/assets/274d66a9-a0f5-4783-9a80-1dd0d3def34b)


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
