### PR TITLE
[Feature(auction_item)] 경매 물품 상세 조회 시 판매자의 정보 추가 기능 구현 완료 및 버그 수정

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemController.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemController.java
@@ -56,11 +56,11 @@ public class AuctionItemController {
             .body(ApiResponse.success("경매 물품 등록에 성공했습니다.", auctionItemRes));
     }
 
-    // 경매 물품 상세 조회 (입찰가 포함)
+    // 경매 물품 상세 조회 (입찰가, 판매자 정보 포함)
     @GetMapping("/{auctionItemId}/info")
     public ResponseEntity<ApiResponse<SearchAuctionItemBidRes>> getAuctionItem(
         @PathVariable long auctionItemId) {
-        SearchAuctionItemBidRes searchAuctionItemBidRes = auctionItemService.getAuctionItemWithMaxBid(
+        SearchAuctionItemBidRes searchAuctionItemBidRes = auctionItemService.getAuctionItem(
             auctionItemId);
 
         return ResponseEntity

--- a/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemController.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/controller/AuctionItemController.java
@@ -12,6 +12,7 @@ import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemBidRes;
 import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemCategory;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemSize;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
 import nbc.mushroom.domain.auction_item.service.AuctionItemService;
 import nbc.mushroom.domain.common.annotation.Auth;
 import nbc.mushroom.domain.common.dto.ApiResponse;
@@ -81,12 +82,13 @@ public class AuctionItemController {
         @RequestParam(value = "startDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime startDate,
         @RequestParam(value = "endDate", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDateTime endDate,
         @RequestParam(value = "minPrice", required = false) Long minPrice,
-        @RequestParam(value = "maxPrice", required = false) Long maxPrice) {
+        @RequestParam(value = "maxPrice", required = false) Long maxPrice,
+        @RequestParam(value = "status", required = false) AuctionItemStatus status) {
 
         Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(sort, sortOrder));
         Page<SearchAuctionItemRes> filteredAuctionItems = auctionItemService.getFilteredAuctionItems(
             sort, sortOrder, keyword, brand, category, size, startDate, endDate, minPrice,
-            maxPrice, pageable);
+            maxPrice, status, pageable);
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/nbc/mushroom/domain/auction_item/dto/response/AuctionItemBidInfoRes.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/dto/response/AuctionItemBidInfoRes.java
@@ -2,13 +2,15 @@ package nbc.mushroom.domain.auction_item.dto.response;
 
 public record AuctionItemBidInfoRes(
     String bidderNickname,
-    Long maxPrice
+    Long maxPrice,
+    String imageUrl
 
 ) {
 
-    public AuctionItemBidInfoRes(String bidderNickname, Long maxPrice) {
+    public AuctionItemBidInfoRes(String bidderNickname, Long maxPrice, String imageUrl) {
         this.bidderNickname = bidderNickname;
         this.maxPrice = maxPrice;
+        this.imageUrl = imageUrl;
     }
 }
 

--- a/src/main/java/nbc/mushroom/domain/auction_item/dto/response/SearchAuctionItemBidRes.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/dto/response/SearchAuctionItemBidRes.java
@@ -1,10 +1,15 @@
 package nbc.mushroom.domain.auction_item.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemCategory;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemSize;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemStatus;
+import nbc.mushroom.domain.review.entity.Review;
+import nbc.mushroom.domain.user.entity.User;
 
 public record SearchAuctionItemBidRes(
     Long auctionItemId,
@@ -18,11 +23,12 @@ public record SearchAuctionItemBidRes(
     LocalDateTime startTime,
     LocalDateTime endTime,
     AuctionItemStatus status,
-    AuctionItemBidInfoRes bid
+    AuctionItemBidInfoRes bid,
+    SellerRes seller
 ) {
 
     public static SearchAuctionItemBidRes from(AuctionItem searchAuctionItem,
-        AuctionItemBidInfoRes bid) {
+        AuctionItemBidInfoRes bid, List<Review> reviews) {
         return new SearchAuctionItemBidRes(
             searchAuctionItem.getId(),
             searchAuctionItem.getName(),
@@ -35,8 +41,29 @@ public record SearchAuctionItemBidRes(
             searchAuctionItem.getStartTime(),
             searchAuctionItem.getEndTime(),
             searchAuctionItem.getStatus(),
-            bid
+            bid,
+            new SellerRes(searchAuctionItem.getSeller(), reviews)
         );
     }
 
+    @NoArgsConstructor
+    @Getter
+    private static class SellerRes {
+
+        private String nickname;
+        private String imageUrl;
+        private Double averageScore;
+        private Integer totalReviewCount;
+
+        public SellerRes(User seller, List<Review> reviews) {
+            this.nickname = seller.getNickname();
+            this.imageUrl = seller.getImageUrl();
+            this.averageScore = reviews.stream()
+                .mapToInt(Review::getScore)
+                .average()
+                .orElse(0.0);
+            this.totalReviewCount = reviews.size();
+
+        }
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryCustom.java
@@ -29,7 +29,7 @@ public interface AuctionItemRepositoryCustom {
     Page<SearchAuctionItemRes> findAuctionItemsByKeywordAndFiltering(
         String sort, String sortOrder, String keyword, String brand, AuctionItemCategory category,
         AuctionItemSize size, LocalDateTime startDate, LocalDateTime endDate,
-        Long minPrice, Long maxPrice, Pageable pageable);
+        Long minPrice, Long maxPrice, AuctionItemStatus status, Pageable pageable);
 
     // 경매 물품 상태별 필터링 조회
     Page<AuctionItemStatusRes> findAuctionItemsByStatus(

--- a/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/repository/AuctionItemRepositoryImpl.java
@@ -63,10 +63,10 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
     public Page<SearchAuctionItemRes> findAuctionItemsByKeywordAndFiltering(
         String sort, String sortOrder, String keyword, String brand, AuctionItemCategory category,
         AuctionItemSize size, LocalDateTime startDate, LocalDateTime endDate, Long minPrice,
-        Long maxPrice, Pageable pageable) {
+        Long maxPrice, AuctionItemStatus status, Pageable pageable) {
 
         BooleanBuilder builder = auctionItemsBuilder(
-            keyword, brand, category, size, startDate, endDate, minPrice, maxPrice
+            keyword, brand, category, size, startDate, endDate, minPrice, maxPrice, status
         );
 
         JPAQuery<SearchAuctionItemRes> query = queryFactory
@@ -224,7 +224,7 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
     private BooleanBuilder auctionItemsBuilder(
         String keyword, String brand, AuctionItemCategory category,
         AuctionItemSize size, LocalDateTime startDate, LocalDateTime endDate,
-        Long minPrice, Long maxPrice) {
+        Long minPrice, Long maxPrice, AuctionItemStatus status) {
 
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -262,10 +262,14 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepositoryCustom {
             builder.and(auctionItem.startPrice.loe(maxPrice));
         }
 
-        builder.and(
-            auctionItem.status.eq(AuctionItemStatus.WAITING)
-                .or(auctionItem.status.eq(AuctionItemStatus.PROGRESSING))
-        );
+        if (status != null) {
+            builder.and(auctionItem.status.eq(status));
+        } else {
+            builder.and(
+                auctionItem.status.eq(AuctionItemStatus.WAITING)
+                    .or(auctionItem.status.eq(AuctionItemStatus.PROGRESSING)));
+        }
+
         return builder;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemService.java
@@ -47,12 +47,13 @@ public class AuctionItemService {
     private final BidRepository bidRepository;
     private final ConcurrentHashMap<String, Integer> popularKeywordsMap = new ConcurrentHashMap<>();
     private final ReviewRepository reviewRepository;
+    private final AuctionItemStatusService auctionItemStatusService;
 
     // 경매 물품 키워드 검색(조회)
     public Page<SearchAuctionItemRes> getFilteredAuctionItems(String sort,
         String sortOrder, String keyword, String brand, AuctionItemCategory category,
         AuctionItemSize size, LocalDateTime startDate, LocalDateTime endDate, Long minPrice,
-        Long maxPrice, Pageable pageable) {
+        Long maxPrice, AuctionItemStatus status, Pageable pageable) {
 
         if (keyword != null && !keyword.isEmpty()) {
             savePopularKeywords(keyword);
@@ -60,7 +61,7 @@ public class AuctionItemService {
 
         return auctionItemRepository.findAuctionItemsByKeywordAndFiltering(
             sort, sortOrder, keyword, brand, category, size, startDate, endDate, minPrice, maxPrice,
-            pageable);
+            status, pageable);
     }
 
     // 경매 물품 상제 조회 (최고 입찰가, 판매자 정보)

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -136,7 +136,8 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
             .select(Projections.constructor(
                 AuctionItemBidInfoRes.class,
                 bid.bidder.nickname,
-                bid.biddingPrice
+                bid.biddingPrice,
+                bid.bidder.imageUrl
             ))
             .from(bid)
             .innerJoin(bid.auctionItem, auctionItem)

--- a/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryCustom.java
@@ -7,5 +7,4 @@ public interface ReviewRepositoryCustom {
 
     List<Review> findAllBySellerId(Long sellerId);
 
-    Review findByBidIdAndUserId(Long bidId, Long id);
 }

--- a/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/review/repository/ReviewRepositoryImpl.java
@@ -26,14 +26,4 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             .fetch();
     }
 
-    @Override
-    public Review findByBidIdAndUserId(Long bidId, Long id) {
-        return queryFactory
-            .selectFrom(review)
-            .innerJoin(review.bid, bid)
-            .where(bid.id.eq(bidId)
-                .and(bid.bidder.id.eq(id)))
-            .fetchOne();
-    }
-
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #112 
close #115 

## 📝 요약

> 경매 물품 상세 조회시, 입찰자의 imageUrl 추가, 판매자 정보 추가 및 전체 리뷰개수까지 보이도록 구현하였습니다.


![image (29)](https://github.com/user-attachments/assets/57f3118e-f6a7-4002-8c85-f636d39a9c47)


## 💬 참고사항

> 유저가 경매물품 조회 상태를 기본값은 WAITING 또는 PROGRESSING으로 보되, 이외 원하는 상태가 있다면 볼 수 있도록 필터링 구현까지 함께 작업하였습니다(status 추가).

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
