### PR TITLE
[Bug(config)] 리뷰 조회할 때 filter 안거치게, 경매물품 상세 조회에서 sellerId도 포함

### DIFF
--- a/src/main/java/nbc/mushroom/config/JwtFilter.java
+++ b/src/main/java/nbc/mushroom/config/JwtFilter.java
@@ -33,6 +33,7 @@ public class JwtFilter implements Filter {
         "/api/auction-items/*/info", List.of("GET"),
         "/api/auction-items/search", List.of("GET"),
         "/api/users/*/info", List.of("GET"),
+        "/api/sellers/*/reviews", List.of("GET"),
         "/api/auth/**", List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
     );
 

--- a/src/main/java/nbc/mushroom/domain/auction_item/dto/response/SearchAuctionItemBidRes.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/dto/response/SearchAuctionItemBidRes.java
@@ -50,12 +50,14 @@ public record SearchAuctionItemBidRes(
     @Getter
     private static class SellerRes {
 
+        private Long id;
         private String nickname;
         private String imageUrl;
         private Double averageScore;
         private Integer totalReviewCount;
 
         public SellerRes(User seller, List<Review> reviews) {
+            this.id = seller.getId();
             this.nickname = seller.getNickname();
             this.imageUrl = seller.getImageUrl();
             this.averageScore = reviews.stream()


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #117

## 📝 요약

리뷰 조회할 때 filter 안거치게하고 [`82c5aab1`](https://github.com/mushroom-4/mushroom-be/commit/82c5aab15fc135e68183a431272460cc87a3746c), 경매물품 상세 조회에서 sellerId도 포함했습니다 [`01ebc590`](https://github.com/mushroom-4/mushroom-be/commit/01ebc590029848116b4ff678bed0a42b65110169)

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
