### PR TITLE
[Bug(chat)] 전송 오류 시 웹소켓 연결 끊기는 현상 수정

### DIFF
--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -164,7 +164,9 @@ public class StompHandler implements ChannelInterceptor {
             }
 
             if (Boolean.FALSE.equals(createBidService.hasBid(loginUserId, chatRoomId))) {
-                throw new CustomException(BIDDING_REQUIRED);
+                log.error(BIDDING_REQUIRED.getMessage());
+                stompHeaderAccessor.getSessionAttributes()
+                    .put("error", BIDDING_REQUIRED.getMessage());
             }
 
             log.info("✅ SEND 성공: userId={}, chatRoomId={}", loginUserId, chatRoomId);

--- a/src/main/java/nbc/mushroom/domain/chat/controller/ChatController.java
+++ b/src/main/java/nbc/mushroom/domain/chat/controller/ChatController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,10 +32,11 @@ public class ChatController {
     public ChatMessageRes sendChatMessage(
         @DestinationVariable Long chatRoomId,
         @Valid @Payload ChatMessageReq chatMessageReq,
+        StompHeaderAccessor stompHeaderAccessor,
         @Auth AuthUser authUser
     ) {
         log.info("Auth User ID : {} ", authUser.id());
-        return chatService.sendChatMessage(chatRoomId, chatMessageReq,
+        return chatService.sendChatMessage(chatRoomId, chatMessageReq, stompHeaderAccessor,
             User.fromAuthUser(authUser));
     }
 

--- a/src/main/java/nbc/mushroom/domain/chat/entity/MessageType.java
+++ b/src/main/java/nbc/mushroom/domain/chat/entity/MessageType.java
@@ -1,5 +1,5 @@
 package nbc.mushroom.domain.chat.entity;
 
 public enum MessageType {
-    MESSAGE, ANNOUNCEMENT
+    MESSAGE, ANNOUNCEMENT, ERROR
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -70,6 +70,22 @@ public class ChatService {
 
         redisPublish.publish(announcementMessageRes);
     }
+
+    /**
+     * 일반 메시지 생성 메서드
+     */
+    private ChatMessage createChatMessage(Long chatRoomId, String message, User sender) {
+        log.info("ChatMessage 객체 생성 [ChatRoomId : {}] [SenderId : {}]", chatRoomId,
+            sender.getId());
+        return ChatMessage.builder()
+            .chatRoomId(chatRoomId)
+            .messageType(MessageType.MESSAGE)
+            .message(message)
+            .sendDateTime(LocalDateTime.now())
+            .sender(sender)
+            .build();
+    }
+
     /**
      * 에러 메시지 생성 메서드
      */

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package nbc.mushroom.domain.chat.service;
 
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -59,7 +60,12 @@ public class ChatService {
 
     public void sendBidAnnouncementMessage(Long chatRoomId, User bidder,
         Long biddingPrice) {
-        String message = biddingPrice + "원에 입찰하였습니다. ";
+
+        NumberFormat numberFormat = NumberFormat.getInstance(Locale.KOREA);
+        String formattedPrice = numberFormat.format(biddingPrice);
+
+        String message = formattedPrice + "원에 입찰하였습니다.";
+
         ChatMessage announcementMessage = ChatMessage.builder()
             .chatRoomId(chatRoomId)
             .messageType(MessageType.ANNOUNCEMENT)
@@ -69,7 +75,7 @@ public class ChatService {
             .build();
 
         log.info("AnnouncementMessage 객체 생성 [ChatRoomId : {}] [SenderId : {}]", chatRoomId,
-            announcementMessage);
+            bidder.getId());
 
         ChatMessageRes announcementMessageRes = ChatMessageRes.from(announcementMessage);
         saveChatMessage(chatRoomId, announcementMessageRes);

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -11,6 +11,7 @@ import nbc.mushroom.domain.chat.entity.ChatMessage;
 import nbc.mushroom.domain.chat.entity.MessageType;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -68,6 +69,24 @@ public class ChatService {
         saveChatMessage(chatRoomId, announcementMessageRes);
 
         redisPublish.publish(announcementMessageRes);
+    }
+    /**
+     * 에러 메시지 생성 메서드
+     */
+    private ChatMessage createErrorMessage(Long chatRoomId,
+        StompHeaderAccessor stompHeaderAccessor,
+        User sender) {
+        ChatMessage chatErrorMessage = ChatMessage.builder()
+            .chatRoomId(chatRoomId)
+            .messageType(MessageType.ERROR)
+            .message((String) stompHeaderAccessor.getSessionAttributes().get("error"))
+            .sendDateTime(LocalDateTime.now())
+            .sender(sender)
+            .build();
+
+        log.info("ErrorMessage 객체 생성 [ChatRoomId : {}] [SenderId : {}] [ErrorMessage : {}]",
+            chatRoomId, sender.getId(), chatErrorMessage.getMessage());
+        return chatErrorMessage;
     }
 
     /**

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -101,4 +101,13 @@ public class ChatService {
             .map(o -> (ChatMessageRes) o) // Object → ChatMessage 변환
             .toList(); // 최종 List<ChatMessageRes> 반환
     }
+
+    /**
+     * 에러 메시지가 존재하는지 확인
+     */
+    private boolean hasErrorMessage(StompHeaderAccessor stompHeaderAccessor) {
+        String error = (String) Objects.requireNonNull(stompHeaderAccessor.getSessionAttributes())
+            .get("error");
+        return error != null;
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -3,6 +3,8 @@ package nbc.mushroom.domain.chat.service;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.chat.dto.request.ChatMessageReq;
@@ -26,25 +28,29 @@ public class ChatService {
     /**
      * 클라이언트가 보낸 메시지를 Redis에 저장하고 전송
      *
+     * hasErrorMessage가 true면 에러메시지 생성, false면 일반 메시지 생성
+     *
      * @param chatRoomId     : 메시지 전송될 채팅방 ID
      * @param chatMessageReq : 클라이언트가 보낸 메시지 요청 Dto
      * @param loginUser      : 현재 로그인한 유저 (메시지 보낸 사람)
+     * @param stompHeaderAccessor : STOMP 헤더 정보에 접근하기 위한 클래스 (Error메시지가 담겼는지 확인하기 위해)
      */
     public ChatMessageRes sendChatMessage(Long chatRoomId, ChatMessageReq chatMessageReq,
+        StompHeaderAccessor stompHeaderAccessor,
         User loginUser) {
 
-        ChatMessage chatMessage = ChatMessage.builder()
-            .chatRoomId(chatRoomId)
-            .messageType(MessageType.MESSAGE)
-            .message(chatMessageReq.message())
-            .sendDateTime(LocalDateTime.now())
-            .sender(loginUser)
-            .build();
+        boolean isError = hasErrorMessage(stompHeaderAccessor);
 
-        log.info("ChatMessage 객체 생성 [ChatRoomId : {}] [SenderId : {}]", chatRoomId, chatMessage);
+        ChatMessage chatMessage = isError
+            ? createErrorMessage(chatRoomId, stompHeaderAccessor, loginUser)
+            : createChatMessage(chatRoomId, chatMessageReq.message(), loginUser);
 
         ChatMessageRes chatMessageRes = ChatMessageRes.from(chatMessage);
-        saveChatMessage(chatRoomId, chatMessageRes);
+
+        // 에러 메시지가 아닐 때만 저장
+        if (!isError) {
+            saveChatMessage(chatRoomId, chatMessageRes);
+        }
 
         redisPublish.publish(chatMessageRes);
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -145,11 +145,16 @@
    */
   function handleSubscriptionMessage(messageOutput) {
     const data = JSON.parse(messageOutput.body);
-    if (Array.isArray(data)) {
-      data.forEach(appendMessage);
-    } else {
-      appendMessage(data);
+
+    // 에러 메시지인 경우 경고창 표시
+    if (data.messageType === "ERROR") {
+      if (data.senderId === myUserId) {
+        alert(data.message);
+      }
+      return;
     }
+
+    appendMessage(data);
   }
 
   /**


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #이슈번호

close #113

## 📝 요약

> 무엇을 했는지 요약

- 채팅 전송 권한이 없는 사용자가 채팅을 보낼 시 웹소켓 연결이 끊기는 현상을 해결했습니다.
- 입찰 금액 전송 시 천 단위 구분자를 추가해 가독성을 향상시켰습니다.

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

- ChatService의 전체적인 리팩토링을 했습니다. 
- 오류메시지를 라우팅으로 보내는 식으로 서버에서 처리하고 싶었는데 클라이언트 측으로 전달이 계~속 안되어서 브로드캐스트로 전송 후 프론트 쪽에서 필터링 하는 방식으로 가야 할 것 같습니다.. (html 관련 커밋 3f1513dd2301b2aceacf7919eac0a106bd4df1d4)

https://github.com/user-attachments/assets/85f96952-7c5a-40c8-a51c-19d5cfb610d9


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
