### PR TITLE
[Bug(popular-keywords)] 인기 검색어 캐싱 기능에서 서버 종료 시 캐싱 내역이 사라지는 현상 수정

### DIFF
--- a/src/main/java/nbc/mushroom/config/RedisCacheConfig.java
+++ b/src/main/java/nbc/mushroom/config/RedisCacheConfig.java
@@ -1,0 +1,42 @@
+package nbc.mushroom.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    /**
+     * StringRedisSerializer - Key 직렬화 GenericJackson2JsonRedisSerializer - Value 직렬화
+     */
+//    @Bean
+//    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+//        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+//            .entryTtl(Duration.ofHours(1))
+//            .serializeKeysWith(
+//                RedisSerializationContext.SerializationPair.fromSerializer(
+//                    new StringRedisSerializer())) // Key 직렬화 설정
+//            .serializeValuesWith(
+//                RedisSerializationContext.SerializationPair.fromSerializer(
+//                    new GenericJackson2JsonRedisSerializer())); // Value 직렬화 설정
+//
+//        return RedisCacheManager.builder(redisConnectionFactory)
+//            .cacheDefaults(config)
+//            .build();
+//    }
+    @Bean
+    public RedisTemplate<String, String> redisCacheTemplate(
+        RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/entity/AuctionItem.java
@@ -123,7 +123,7 @@ public class AuctionItem extends Timestamped {
         this.status = AuctionItemStatus.COMPLETED;
     }
 
-    public void nonTrade() { // TODO 카멡케이스로 바꿈
+    public void nonTrade() {
         if (this.status != PROGRESSING) {
             throw new CustomException(INVALID_AUCTION_ITEM_STATUS);
         }


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #107 

## 📝 요약

> 인기 검색어 기능 구현 시 캐싱에 Cache Manager를 사용했었는데, 서버가 종료되면 캐싱 내역도 사라지게 되는 버그가 있어 이를 보완하기 위해 레디스 템플릿을 이용해 로직을 다시 구성했습니다. 서버가 종료되어도 캐싱이 되어있는 것은 확인했지만 만료 정책에 따라 다시 로직을 수정해야 할 듯합니다. 

## 💬 참고사항

> 만료 정책이 변경됨에 따라 다시 로직 수정이 이뤄져야 할 것 같습니다. 레디스 템플릿으로 변경한 내역까지만 PR 올리겠습니다. 완전히 다른 로직으로 변경되어야 한다면 PR Close 하셔도 무방합니다! 

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
