### PR TITLE
[Bug(bid)] 입찰 내역에서 리뷰 조회 가능하도록 변경

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/dto/response/SearchAuctionItemRes.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/dto/response/SearchAuctionItemRes.java
@@ -20,19 +20,19 @@ public record SearchAuctionItemRes(
     AuctionItemStatus status
 ) {
 
-    public static SearchAuctionItemRes from(AuctionItem searchAuctionItem) {
+    public static SearchAuctionItemRes from(AuctionItem auctionItem) {
         return new SearchAuctionItemRes(
-            searchAuctionItem.getId(),
-            searchAuctionItem.getName(),
-            searchAuctionItem.getDescription(),
-            searchAuctionItem.getImageUrl(),
-            searchAuctionItem.getSize(),
-            searchAuctionItem.getCategory(),
-            searchAuctionItem.getBrand(),
-            searchAuctionItem.getStartPrice(),
-            searchAuctionItem.getStartTime(),
-            searchAuctionItem.getEndTime(),
-            searchAuctionItem.getStatus()
+            auctionItem.getId(),
+            auctionItem.getName(),
+            auctionItem.getDescription(),
+            auctionItem.getImageUrl(),
+            auctionItem.getSize(),
+            auctionItem.getCategory(),
+            auctionItem.getBrand(),
+            auctionItem.getStartPrice(),
+            auctionItem.getStartTime(),
+            auctionItem.getEndTime(),
+            auctionItem.getStatus()
         );
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/controller/BidController.java
+++ b/src/main/java/nbc/mushroom/domain/bid/controller/BidController.java
@@ -1,6 +1,7 @@
 package nbc.mushroom.domain.bid.controller;
 
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.dto.response.BidInfoRes;
 import nbc.mushroom.domain.bid.dto.response.BidRes;
 import nbc.mushroom.domain.bid.service.BidService;
 import nbc.mushroom.domain.common.annotation.Auth;
@@ -41,15 +42,15 @@ public class BidController {
     }
 
     @GetMapping("/{bidId}")
-    public ResponseEntity<ApiResponse<BidRes>> getBid(
+    public ResponseEntity<ApiResponse<BidInfoRes>> getBid(
         @Auth AuthUser authUser,
         @PathVariable Long bidId
     ) {
         User loginUser = User.fromAuthUser(authUser);
-        BidRes bidRes = bidService.getBidByUser(loginUser, bidId);
+        BidInfoRes bidInfoRes = bidService.getBidByUser(loginUser, bidId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ApiResponse.success("입찰 내역 상세 조회에 성공했습니다.", bidRes));
+            .body(ApiResponse.success("입찰 내역 상세 조회에 성공했습니다.", bidInfoRes));
     }
 
     @DeleteMapping("/{bidId}/cancel")

--- a/src/main/java/nbc/mushroom/domain/bid/dto/response/BidInfoRes.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/response/BidInfoRes.java
@@ -5,6 +5,7 @@ import nbc.mushroom.domain.auction_item.entity.AuctionItemCategory;
 import nbc.mushroom.domain.auction_item.entity.AuctionItemSize;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
+import nbc.mushroom.domain.review.entity.Review;
 
 public record BidInfoRes(
     Long bidId,
@@ -14,7 +15,7 @@ public record BidInfoRes(
     ReviewRes review
 ) {
 
-    public static BidInfoRes from(Bid bid) {
+    public static BidInfoRes from(Bid bid, Review review) {
         return new BidInfoRes(
             bid.getId(),
             bid.getBiddingPrice(),
@@ -30,10 +31,10 @@ public record BidInfoRes(
                 bid.getAuctionItem().getStartTime(),
                 bid.getAuctionItem().getEndTime()
             ),
-            bid.getReview() == null ? null : new BidInfoRes.ReviewRes(
-                bid.getReview().getId(),
-                bid.getReview().getContent(),
-                bid.getReview().getScore()
+            review == null ? null : new BidInfoRes.ReviewRes(
+                review.getId(),
+                review.getContent(),
+                review.getScore()
             )
         );
     }

--- a/src/main/java/nbc/mushroom/domain/bid/dto/response/BidInfoRes.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/response/BidInfoRes.java
@@ -1,0 +1,62 @@
+package nbc.mushroom.domain.bid.dto.response;
+
+import java.time.LocalDateTime;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemCategory;
+import nbc.mushroom.domain.auction_item.entity.AuctionItemSize;
+import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.bid.entity.BiddingStatus;
+
+public record BidInfoRes(
+    Long bidId,
+    Long biddingPrice,
+    BiddingStatus biddingStatus,
+    AuctionItemRes auctionItem,
+    ReviewRes review
+) {
+
+    public static BidInfoRes from(Bid bid) {
+        return new BidInfoRes(
+            bid.getId(),
+            bid.getBiddingPrice(),
+            bid.getBiddingStatus(),
+            new BidInfoRes.AuctionItemRes(
+                bid.getAuctionItem().getId(),
+                bid.getAuctionItem().getName(),
+                bid.getAuctionItem().getImageUrl(),
+                bid.getAuctionItem().getSize(),
+                bid.getAuctionItem().getCategory(),
+                bid.getAuctionItem().getBrand(),
+                bid.getAuctionItem().getStartPrice(),
+                bid.getAuctionItem().getStartTime(),
+                bid.getAuctionItem().getEndTime()
+            ),
+            bid.getReview() == null ? null : new BidInfoRes.ReviewRes(
+                bid.getReview().getId(),
+                bid.getReview().getContent(),
+                bid.getReview().getScore()
+            )
+        );
+    }
+
+    private record AuctionItemRes(
+        Long id,
+        String name,
+        String imageUrl,
+        AuctionItemSize size,
+        AuctionItemCategory category,
+        String brand,
+        Long startPrice,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+    ) {
+
+    }
+
+    private record ReviewRes(
+        Long id,
+        String content,
+        Integer score
+    ) {
+
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/bid/dto/response/BidRes.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/response/BidRes.java
@@ -1,6 +1,5 @@
 package nbc.mushroom.domain.bid.dto.response;
 
-import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
 
@@ -8,7 +7,7 @@ public record BidRes(
     Long bidId,
     Long biddingPrice,
     BiddingStatus biddingStatus,
-    SearchAuctionItemRes searchAuctionItemRes
+    AuctionItemRes auctionItem
 ) {
 
     public static BidRes from(Bid bid) {
@@ -16,7 +15,17 @@ public record BidRes(
             bid.getId(),
             bid.getBiddingPrice(),
             bid.getBiddingStatus(),
-            SearchAuctionItemRes.from(bid.getAuctionItem())
+            new BidRes.AuctionItemRes(
+                bid.getAuctionItem().getName(),
+                bid.getAuctionItem().getImageUrl()
+            )
         );
+    }
+
+    private record AuctionItemRes(
+        String name,
+        String imageUrl
+    ) {
+
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/dto/response/BidRes.java
+++ b/src/main/java/nbc/mushroom/domain/bid/dto/response/BidRes.java
@@ -11,12 +11,12 @@ public record BidRes(
     SearchAuctionItemRes searchAuctionItemRes
 ) {
 
-    public static BidRes from(Bid bid, SearchAuctionItemRes searchAuctionItemRes) {
+    public static BidRes from(Bid bid) {
         return new BidRes(
             bid.getId(),
             bid.getBiddingPrice(),
             bid.getBiddingStatus(),
-            searchAuctionItemRes
+            SearchAuctionItemRes.from(bid.getAuctionItem())
         );
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -15,7 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,7 +23,6 @@ import lombok.NoArgsConstructor;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.common.entity.Timestamped;
 import nbc.mushroom.domain.common.exception.CustomException;
-import nbc.mushroom.domain.review.entity.Review;
 import nbc.mushroom.domain.user.entity.User;
 
 @Getter
@@ -51,9 +49,6 @@ public class Bid extends Timestamped {
     @Enumerated(EnumType.STRING)
     @Column(name = "bidding_status", nullable = false)
     private BiddingStatus biddingStatus;
-
-    @OneToOne(mappedBy = "bid")
-    private Review review;
 
     @Builder
     public Bid(Long id, AuctionItem auctionItem, User bidder, Long biddingPrice) {

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -15,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,6 +24,7 @@ import lombok.NoArgsConstructor;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.common.entity.Timestamped;
 import nbc.mushroom.domain.common.exception.CustomException;
+import nbc.mushroom.domain.review.entity.Review;
 import nbc.mushroom.domain.user.entity.User;
 
 @Getter
@@ -43,12 +45,15 @@ public class Bid extends Timestamped {
     @JoinColumn(name = "user_id", nullable = false)
     private User bidder;
 
-    @Column(nullable = false)
+    @Column(name = "bidding_price", nullable = false)
     private Long biddingPrice;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "bidding_status", nullable = false)
     private BiddingStatus biddingStatus;
+
+    @OneToOne(mappedBy = "bid")
+    private Review review;
 
     @Builder
     public Bid(Long id, AuctionItem auctionItem, User bidder, Long biddingPrice) {
@@ -88,7 +93,7 @@ public class Bid extends Timestamped {
         if (!biddingPrice.equals(paymentAmount)) {
             throw new CustomException(INVALID_PAYMENT_AMOUNT);
         }
-        
+
         if (this.biddingStatus != SUCCEED) {
             throw new CustomException(INVALID_BID_STATUS);
         }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import nbc.mushroom.domain.auction_item.dto.response.AuctionItemBidInfoRes;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
+import nbc.mushroom.domain.bid.dto.response.BidInfoRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
 import nbc.mushroom.domain.user.entity.User;
@@ -23,6 +24,8 @@ public interface BidRepositoryCustom {
     Page<Bid> findBidsByUser(User user, Pageable pageable);
 
     Bid findBidByBidderAndId(User bidder, Long bidId);
+
+    BidInfoRes findBidInfoByBidderAndId(User bidder, Long bidId);
 
     Long countBidsByBidderAndStatus(User bidder, BiddingStatus biddingStatus);
 

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -8,7 +8,6 @@ import static nbc.mushroom.domain.common.exception.ExceptionType.BID_CANNOT_CANC
 
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
-import nbc.mushroom.domain.auction_item.dto.response.SearchAuctionItemRes;
 import nbc.mushroom.domain.bid.dto.response.BidRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
@@ -28,17 +27,12 @@ public class BidService {
 
     public Page<BidRes> getAllBidsByUser(User loginUser, Pageable pageable) {
         Page<Bid> bidPage = bidRepository.findBidsByUser(loginUser, pageable);
-
-        return bidPage.map(bid ->
-            BidRes.from(bid, SearchAuctionItemRes.from(bid.getAuctionItem())));
+        return bidPage.map(BidRes::from);
     }
 
     public BidRes getBidByUser(User loginUser, Long bidId) {
-        Bid findBid = bidRepository.findBidByBidderAndId(loginUser, bidId);
-        SearchAuctionItemRes searchAuctionItemRes = SearchAuctionItemRes.from(
-            findBid.getAuctionItem());
-
-        return BidRes.from(findBid, searchAuctionItemRes);
+        Bid bid = bidRepository.findBidByBidderAndId(loginUser, bidId);
+        return BidRes.from(bid);
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -8,6 +8,7 @@ import static nbc.mushroom.domain.common.exception.ExceptionType.BID_CANNOT_CANC
 
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.dto.response.BidInfoRes;
 import nbc.mushroom.domain.bid.dto.response.BidRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
@@ -30,9 +31,9 @@ public class BidService {
         return bidPage.map(BidRes::from);
     }
 
-    public BidRes getBidByUser(User loginUser, Long bidId) {
+    public BidInfoRes getBidByUser(User loginUser, Long bidId) {
         Bid bid = bidRepository.findBidByBidderAndId(loginUser, bidId);
-        return BidRes.from(bid);
+        return BidInfoRes.from(bid);
     }
 
     @Transactional(readOnly = false)

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -32,8 +32,7 @@ public class BidService {
     }
 
     public BidInfoRes getBidByUser(User loginUser, Long bidId) {
-        Bid bid = bidRepository.findBidByBidderAndId(loginUser, bidId);
-        return BidInfoRes.from(bid);
+        return bidRepository.findBidInfoByBidderAndId(loginUser, bidId);
     }
 
     @Transactional(readOnly = false)


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #125 

## 📝 요약

입찰 내역에서 리뷰 DTO도 응답하도록 추가하는 과정에서 아래의 변경이 있었습니다.

- BidDto의 정팩메에서 엔티티랑 다른 Dto를 넘겨받는게 불편해보이고 코드도 길어져서 DTO안에서 처리하도록 변경했습니다.
- Bid Entity가 Review를 양방향 참조하도록 했다가 ([`3bda853b`](https://github.com/mushroom-4/mushroom-be/pull/127/commits/3bda853bf5d20cd590e92135f2db3bb91be83ca6)) 양방향 참조 제거하고 다시 구현했습니다. ([`35c2566f`](https://github.com/mushroom-4/mushroom-be/pull/127/commits/35c2566fcccc18eb5d7e9af92a856cedd63c2ca7)) 코드 궁금하신 분들 한 번 보셔요!


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
