### PR TITLE
[Bug(chat)] 메시지 전송 권한이 있음에도 에러메시지가 보이는 오류 수정

### DIFF
--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -152,6 +152,9 @@ public class StompHandler implements ChannelInterceptor {
 
     /**
      * 메시지 전송 시 해당 경매에 입찰한 기록이 있는 유저인지 확인
+     *
+     * 없으면 Error 메시지를 세션에 저장
+     * 웹소켓 연결 중 권한이 생기면 세션에 저장된 Error 메시지 삭제
      */
     private void handleSend(StompHeaderAccessor stompHeaderAccessor) {
         log.info(":::: SEND 요청 감지 ::::");
@@ -167,6 +170,13 @@ public class StompHandler implements ChannelInterceptor {
                 log.error(BIDDING_REQUIRED.getMessage());
                 stompHeaderAccessor.getSessionAttributes()
                     .put("error", BIDDING_REQUIRED.getMessage());
+            }
+
+            //  세션에 error 값이 있는지 체크
+            if (Boolean.TRUE.equals(createBidService.hasBid(loginUserId, chatRoomId))
+                && stompHeaderAccessor.getSessionAttributes().get("error") != null) {
+                stompHeaderAccessor.getSessionAttributes().remove("error");
+                log.info("입찰 내역 확인. 기존 에러 메시지 세션에서 삭제");
             }
 
             log.info("✅ SEND 성공: userId={}, chatRoomId={}", loginUserId, chatRoomId);

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.auction_item.service.AuctionItemService;
-import nbc.mushroom.domain.bid.service.CreateBidService;
+import nbc.mushroom.domain.bid.service.BidService;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.common.util.JwtUtil;
 import nbc.mushroom.domain.common.util.StompDestinationUtils;
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StompHandler implements ChannelInterceptor {
 
-    private final CreateBidService createBidService;
+    private final BidService bidService;
     private final AuctionItemService auctionItemService;
     private final JwtUtil jwtUtil;
 
@@ -166,14 +166,14 @@ public class StompHandler implements ChannelInterceptor {
                 throw new CustomException(AUTH_TOKEN_NOT_FOUND);
             }
 
-            if (Boolean.FALSE.equals(createBidService.hasBid(loginUserId, chatRoomId))) {
+            if (Boolean.FALSE.equals(bidService.hasBid(loginUserId, chatRoomId))) {
                 log.error(BIDDING_REQUIRED.getMessage());
                 stompHeaderAccessor.getSessionAttributes()
                     .put("error", BIDDING_REQUIRED.getMessage());
             }
 
             //  세션에 error 값이 있는지 체크
-            if (Boolean.TRUE.equals(createBidService.hasBid(loginUserId, chatRoomId))
+            if (Boolean.TRUE.equals(bidService.hasBid(loginUserId, chatRoomId))
                 && stompHeaderAccessor.getSessionAttributes().get("error") != null) {
                 stompHeaderAccessor.getSessionAttributes().remove("error");
                 log.info("입찰 내역 확인. 기존 에러 메시지 세션에서 삭제");

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -14,6 +14,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -146,7 +147,7 @@ public class StompHandler implements ChannelInterceptor {
             log.info("✅ SUBSCRIBE 성공: userId={}, chatRoomId={}", userId, chatRoomId);
         } catch (Exception e) {
             log.error("❌ SUBSCRIBE 실패: {}", e.getMessage());
-            throw e; // 예외를 던져야 STOMP에서 처리 가능
+            throw e;
         }
     }
 
@@ -166,23 +167,14 @@ public class StompHandler implements ChannelInterceptor {
                 throw new CustomException(AUTH_TOKEN_NOT_FOUND);
             }
 
-            if (Boolean.FALSE.equals(bidService.hasBid(loginUserId, chatRoomId))) {
-                log.error(BIDDING_REQUIRED.getMessage());
-                stompHeaderAccessor.getSessionAttributes()
-                    .put("error", BIDDING_REQUIRED.getMessage());
-            }
+            boolean hasBid = Boolean.TRUE.equals(bidService.hasBid(loginUserId, chatRoomId));
 
-            //  세션에 error 값이 있는지 체크
-            if (Boolean.TRUE.equals(bidService.hasBid(loginUserId, chatRoomId))
-                && stompHeaderAccessor.getSessionAttributes().get("error") != null) {
-                stompHeaderAccessor.getSessionAttributes().remove("error");
-                log.info("입찰 내역 확인. 기존 에러 메시지 세션에서 삭제");
-            }
+            validateBidAndSessionAttributeError(stompHeaderAccessor, hasBid);
 
             log.info("✅ SEND 성공: userId={}, chatRoomId={}", loginUserId, chatRoomId);
         } catch (Exception e) {
             log.error("❌ SEND 실패: {}", e.getMessage());
-            throw e; // 예외를 던져야 STOMP에서 처리 가능
+            throw e;
         }
     }
 
@@ -192,5 +184,27 @@ public class StompHandler implements ChannelInterceptor {
     private String getAuthorizationHeader(StompHeaderAccessor accessor) {
         List<String> authHeaders = accessor.getNativeHeader("Authorization");
         return (authHeaders != null && !authHeaders.isEmpty()) ? authHeaders.get(0) : null;
+    }
+
+    /**
+     * 세션에서 입찰 여부에 따라 에러 메시지를 추가하거나 삭제하는 메서드
+     *
+     * 입찰하지 않은 경우: 에러 메시지를 세션에 추가
+     * 입찷한 경우 & 세션에 에러메시지가 존재하는 경우 : 기존에 존재하는 에러 메시지를 삭제
+     */
+    private void validateBidAndSessionAttributeError(StompHeaderAccessor stompHeaderAccessor,
+        boolean hasBid) {
+        Map<String, Object> sessionAttributes = stompHeaderAccessor.getSessionAttributes();
+
+        if (!hasBid) {
+            log.error("입찰 필요: {}", BIDDING_REQUIRED.getMessage());
+            sessionAttributes.put("error", BIDDING_REQUIRED.getMessage());
+            return; // 이후 로직 실행할 필요 없음
+        }
+
+        if (sessionAttributes.get("error") != null) {
+            log.info("입찰 내역이 확인됨 - 기존 에러 메시지 삭제");
+            sessionAttributes.remove("error");
+        }
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -44,6 +44,10 @@ public class BidService {
         findBid.cancel();
     }
 
+    public Boolean hasBid(Long bidderId, Long auctionItemId) {
+        return bidRepository.existBidByBidderIdAndAuctionItemId(bidderId, auctionItemId);
+    }
+
     private void validateBidCancellation(User loginUser, Bid bid) {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/nbc/mushroom/domain/bid/service/CreateBidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/CreateBidService.java
@@ -67,10 +67,6 @@ public class CreateBidService {
         return bidRepository.save(bid);
     }
 
-    public Boolean hasBid(Long bidderId, Long auctionItemId) {
-        return bidRepository.existBidByBidderIdAndAuctionItemId(bidderId, auctionItemId);
-    }
-
     private void validateBidRequest(User bidder, AuctionItem auctionItem, Long biddingPrice) {
         if (auctionItem.getStatus() != AuctionItemStatus.PROGRESSING) {
             throw new CustomException(AUCTION_ITEM_NOT_IN_PROGRESS);


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #128

## 📝 요약

> 무엇을 했는지 요약

- 입찰을 했음에도 불구하고 권한이 없다는 에러 메시지가 반환되는 오류를 수정했습니다.
- CreateBidService에 있던 hasBid() 메서드를 BidService로 옮겼습니다.  (Create랑은 맞지 않는거 같아서..)
- HandleSend 메서드 속 입찰 내역 확인하는 로직을 메서드로 추출해 리팩토링을 했습니다. 

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

- stomp 세션에 "error" 키워드가 있으면 에러메시지를 전송하도록 로직을 짰었는데요, 웹소켓 연결 해제 전까지 세션에 담긴 정보가 유지되어서 발생한 오류였습니다. 원인 파악 후 입찰 내역이 존재하고 세션에 "error" 키워드가 있다면 세션에 담겨있던 "error"를 지우도록 하여 오류를 해결하였습니다. 
 
https://github.com/user-attachments/assets/e5c60217-1052-435a-bc5e-ea94a0679b4d


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
