### PR TITLE
[Refactor(token)] Jwt 토큰 검증 중복 로직 최소화

### DIFF
--- a/src/main/java/nbc/mushroom/config/JwtFilter.java
+++ b/src/main/java/nbc/mushroom/config/JwtFilter.java
@@ -1,9 +1,5 @@
 package nbc.mushroom.config;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -58,41 +54,13 @@ public class JwtFilter implements Filter {
 
         String bearerJwt = httpRequest.getHeader("Authorization");
 
-        if (bearerJwt == null) {
-            // 토큰이 없는 경우 400을 반환합니다.
-            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "JWT 토큰이 필요합니다.");
-            return;
-        }
+        Map<String, Object> userInfo = jwtUtil.getUserInfoFromTokenForHttp(bearerJwt, httpResponse);
 
-        String jwt = jwtUtil.substringToken(bearerJwt);
+        userInfo.forEach(httpRequest::setAttribute);
 
-        try {
-            // JWT 유효성 검사와 claims 추출
-            Claims claims = jwtUtil.extractClaims(jwt);
-            if (claims == null) {
-                httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "잘못된 JWT 토큰입니다.");
-                return;
-            }
-
-            httpRequest.setAttribute("userId", Long.parseLong(claims.getSubject()));
-            httpRequest.setAttribute("email", claims.get("email"));
-            httpRequest.setAttribute("userRole", claims.get("userRole"));
-            httpRequest.setAttribute("nickname", claims.get("nickname"));
-            httpRequest.setAttribute("imageUrl", claims.get("imageUrl"));
-
+        if (userInfo != null) {
+            userInfo.forEach(httpRequest::setAttribute);
             chain.doFilter(request, response);
-        } catch (SecurityException | MalformedJwtException e) {
-            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.", e);
-            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
-        } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token, 만료된 JWT token 입니다.", e);
-            httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
-            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
-            httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
-        } catch (Exception e) {
-            log.error("Internal server error", e);
-            httpResponse.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/nbc/mushroom/config/websocket/StompAuthUserArgumentResolver.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompAuthUserArgumentResolver.java
@@ -40,7 +40,7 @@ public class StompAuthUserArgumentResolver implements HandlerMethodArgumentResol
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
 
         if (sessionAttributes == null || !sessionAttributes.containsKey("userId")) {
-            throw new CustomException(ExceptionType.AUTH_TOKEN_NOT_FOUND);
+            throw new CustomException(ExceptionType.JWT_TOKEN_REQUIRED);
         }
 
         // STOMP 세션에서 사용자 정보 가져오기

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -74,7 +74,7 @@ public class StompHandler implements ChannelInterceptor {
 
         log.info("✅ 받은 토큰: {}", bearerJwt);
 
-        Map<String, Object> userInfo = jwtUtil.parseTokenUserInfo(bearerJwt);
+        Map<String, Object> userInfo = jwtUtil.getUserInfoFromTokenForWebSocket(bearerJwt);
 
         stompHeaderAccessor.getSessionAttributes().putAll(userInfo);
 

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -1,8 +1,8 @@
 package nbc.mushroom.config.websocket;
 
-import static nbc.mushroom.domain.common.exception.ExceptionType.AUTH_TOKEN_NOT_FOUND;
 import static nbc.mushroom.domain.common.exception.ExceptionType.BIDDING_REQUIRED;
 import static nbc.mushroom.domain.common.exception.ExceptionType.CHAT_ROOM_NOT_FOUND;
+import static nbc.mushroom.domain.common.exception.ExceptionType.JWT_TOKEN_REQUIRED;
 
 import java.util.List;
 import java.util.Map;
@@ -91,7 +91,7 @@ public class StompHandler implements ChannelInterceptor {
             Long userId = (Long) stompHeaderAccessor.getSessionAttributes().get("userId");
 
             if (userId == null) {
-                throw new CustomException(AUTH_TOKEN_NOT_FOUND);
+                throw new CustomException(JWT_TOKEN_REQUIRED);
             }
 
             log.info("✅ SUBSCRIBE 요청 destination: {}", stompHeaderAccessor.getDestination());
@@ -121,7 +121,7 @@ public class StompHandler implements ChannelInterceptor {
             Long loginUserId = (Long) stompHeaderAccessor.getSessionAttributes().get("userId");
 
             if (loginUserId == null) {
-                throw new CustomException(AUTH_TOKEN_NOT_FOUND);
+                throw new CustomException(JWT_TOKEN_REQUIRED);
             }
 
             boolean hasBid = Boolean.TRUE.equals(bidService.hasBid(loginUserId, chatRoomId));

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -17,7 +17,7 @@ public enum ExceptionType {
     // Auth
     AUTH_WRONG_USED(HttpStatus.INTERNAL_SERVER_ERROR, "A01", "@Auth와 AuthUser 타입은 함께 사용되어야 합니다."),
     AUTH_FAILED(HttpStatus.BAD_REQUEST, "A02", "이메일 또는 비밀번호가 일치하지 않습니다."),
-    AUTH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "A03", "토큰을 찾을 수 없습니다."),
+    JWT_TOKEN_REQUIRED(HttpStatus.BAD_REQUEST, "A03", "JWT 토큰이 필요합니다."),
     INVALID_JWT(HttpStatus.BAD_REQUEST, "A04", "잘못된 JWT 토큰입니다."),
     INVALID_JWT_SIGNATURE(HttpStatus.UNAUTHORIZED, "A05", "유효하지 않은 JWT 서명입니다."),
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "A06", "만료된 JWT 토큰입니다."),

--- a/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
@@ -1,6 +1,5 @@
 package nbc.mushroom.domain.common.util;
 
-import static nbc.mushroom.domain.common.exception.ExceptionType.AUTH_TOKEN_NOT_FOUND;
 import static nbc.mushroom.domain.common.exception.ExceptionType.EXPIRED_JWT_TOKEN;
 import static nbc.mushroom.domain.common.exception.ExceptionType.INTERNAL_SERVER_ERROR;
 import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_JWT;

--- a/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
@@ -83,6 +83,17 @@ public class JwtUtil {
     }
 
     /**
+     * JWT 토큰에서 사용자 정보를 가져옴 (WebSocket용)
+     * WebSocket 예외 처리 방식 적용
+     */
+    public Map<String, Object> getUserInfoFromTokenForWebSocket(String bearerToken) {
+        return extractUserInfoFromToken(bearerToken, e -> {
+            log.error("WebSocket 연결 실패 - {}", e.getMessage(), e);
+            throw e;
+        });
+    }
+
+    /**
      * JWT 토큰 검증 후 사용자 정보 추출
      * 사용자 정보 추출은 메서드 호출로 이루어짐
      *

--- a/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
@@ -16,6 +16,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Collections;
@@ -80,6 +82,22 @@ public class JwtUtil {
             .build()
             .parseClaimsJws(token)
             .getBody();
+    }
+
+    /**
+     * JJWT 토큰에서 사용자 정보를 가져옴 (HTTP 용)
+     * HttpResponse 예외 처리 방식 적용
+     */
+    public Map<String, Object> getUserInfoFromTokenForHttp(String bearerToken,
+        HttpServletResponse httpResponse) {
+        return extractUserInfoFromToken(bearerToken, e -> {
+            log.error("Http 연결 실패 - {}", e.getMessage(), e);
+            try {
+                httpResponse.sendError(e.getHttpStatus().value(), e.getMessage());
+            } catch (IOException ex) {
+                log.error("Http 응답 처리 중 오류 발생", ex);
+            }
+        });
     }
 
     /**

--- a/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/JwtUtil.java
@@ -68,7 +68,7 @@ public class JwtUtil {
         if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
             return tokenValue.substring(7);
         }
-        throw new CustomException(AUTH_TOKEN_NOT_FOUND);
+        throw new CustomException(JWT_TOKEN_REQUIRED);
     }
 
     public Claims extractClaims(String token) {
@@ -80,14 +80,10 @@ public class JwtUtil {
     }
 
     /**
-     * JWT 토큰을 검증하고 사용자 정보를 반환
+     * JWT 토큰에서 사용자 정보를 추출
      */
-    public Map<String, Object> parseTokenUserInfo(String bearerToken) {
-        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-            throw new CustomException(AUTH_TOKEN_NOT_FOUND);
-        }
-
-        String jwt = bearerToken.substring(7); // "Bearer " 제거
+    private Map<String, Object> parseTokenUserInfo(String bearerToken) {
+        String jwt = substringToken(bearerToken); // "Bearer " 제거
 
         try {
             Claims claims = extractClaims(jwt);

--- a/src/main/java/nbc/mushroom/domain/common/util/StompUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/StompUtil.java
@@ -1,6 +1,7 @@
 package nbc.mushroom.domain.common.util;
 
 import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_CHAT_ROOM_PATH;
+import static nbc.mushroom.domain.common.exception.ExceptionType.JWT_TOKEN_REQUIRED;
 
 import nbc.mushroom.domain.common.exception.CustomException;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -22,5 +23,16 @@ public class StompUtil {
         }
 
         return Long.parseLong(chatRoomIdStr);
+    }
+
+    /**
+     * STOMP 요청에서 사용자 ID 추출
+     */
+    public static Long getUserId(StompHeaderAccessor stompHeaderAccessor) {
+        Long userId = (Long) stompHeaderAccessor.getSessionAttributes().get("userId");
+        if (userId == null) {
+            throw new CustomException(JWT_TOKEN_REQUIRED);
+        }
+        return userId;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/common/util/StompUtil.java
+++ b/src/main/java/nbc/mushroom/domain/common/util/StompUtil.java
@@ -5,7 +5,7 @@ import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_CHAT_RO
 import nbc.mushroom.domain.common.exception.CustomException;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 
-public class StompDestinationUtils {
+public class StompUtil {
 
     /**
      * STOMP 메시지의 Destination에서 채팅방 ID 추출 후 검증


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #132

## 📝 요약

> 무엇을 했는지 요약

- JwtFilter, StomHandler에서 Jwt토큰 관련 로직이 중복되는 것을 최소화 하였습니다. 
- StompDestinationUtils 클래스 명을 StompUtil로 바꾸고 웹소켓 세션에서 userId를 추출하는 메서드를 추가 구현했습니다. 

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

JwtFilter에서 예외를 처리하는 방식과 StompHandler에서 예외를 처리하는 방식이 달라서 어떻게 해야할지 찾아보는 중에 Consumer<T> 라는 함수형 인터페이스를 알게되었습니다.
관련해서 [✨학습 Merge](https://www.notion.so/yeim/Consumer-T-e702dcfd95d444e4853636bd513cec4a?pvs=4)에 적어놨으니 저처럼 처음 접하시는 분들은 참고해주세요!

+)  계속 보다보니 가독성 적으로 더 좋아진지는 모르겠습니다! (메서드를 타고 타고 타고..)

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
