### PR TITLE
[Feature(chat)] 현재 접속자 목록 구현

### DIFF
--- a/src/main/java/nbc/mushroom/config/websocket/RedisChatConfig.java
+++ b/src/main/java/nbc/mushroom/config/websocket/RedisChatConfig.java
@@ -3,7 +3,6 @@ package nbc.mushroom.config.websocket;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
 import nbc.mushroom.domain.chat.service.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -33,9 +32,7 @@ public class RedisChatConfig {
     }
 
     /**
-     * Redis 기본 설정 ( Key : String Value : ChatMessageRes )
-     * <p>
-     * Redis 쓸 때 사용. 현재는 ChatMessage만 직렬화/역직렬화 수행하도록 설정
+     * Redis 템플릿 - Object
      *
      * @param redisConnectionFactory : Redis 연결
      */
@@ -53,8 +50,8 @@ public class RedisChatConfig {
         objectMapper.enable(
             SerializationFeature.INDENT_OUTPUT); // 읽기 쉽게 들여쓰기 활성화 (디버깅 용도, 베포 시엔 성능을 위해 비활성화)
 
-        Jackson2JsonRedisSerializer<ChatMessageRes> serializer = new Jackson2JsonRedisSerializer<>(
-            objectMapper, ChatMessageRes.class);
+        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(
+            objectMapper, Object.class);
 
         redisTemplate.setValueSerializer(serializer); // value 직렬화 설정
 

--- a/src/main/java/nbc/mushroom/config/websocket/RedisChatConfig.java
+++ b/src/main/java/nbc/mushroom/config/websocket/RedisChatConfig.java
@@ -41,7 +41,10 @@ public class RedisChatConfig {
         RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
-        redisTemplate.setKeySerializer(new StringRedisSerializer()); // String으로 직렬화 설정
+
+        // key 직렬화 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule()); // 자바의 날짜/시간 API 올바르게 사용할 수 있도록
@@ -53,7 +56,9 @@ public class RedisChatConfig {
         Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(
             objectMapper, Object.class);
 
-        redisTemplate.setValueSerializer(serializer); // value 직렬화 설정
+        // value 직렬화 설정
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
 
         return redisTemplate;
     }

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -100,7 +100,7 @@ public class StompHandler implements ChannelInterceptor {
 
             log.info("✅ SUBSCRIBE 요청 destination: {}", stompHeaderAccessor.getDestination());
 
-            Long chatRoomId = StompUtil.getChatRoomId(stompHeaderAccessor, "/ws/sub");
+            Long chatRoomId = StompUtil.getChatRoomId(stompHeaderAccessor);
             if (FALSE.equals(auctionItemService.hasAuctionItem(chatRoomId))) {
                 throw new CustomException(CHAT_ROOM_NOT_FOUND);
             }
@@ -126,7 +126,7 @@ public class StompHandler implements ChannelInterceptor {
     private void handleSend(StompHeaderAccessor stompHeaderAccessor) {
         log.info(":::: SEND 요청 감지 ::::");
         try {
-            Long chatRoomId = StompUtil.getChatRoomId(stompHeaderAccessor, "/ws/pub");
+            Long chatRoomId = StompUtil.getChatRoomId(stompHeaderAccessor);
             Long loginUserId = StompUtil.getUserId(stompHeaderAccessor);
 
             // '메시지' 전송에서만 실행

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -89,7 +89,9 @@ public class StompHandler implements ChannelInterceptor {
     }
 
     /**
-     * 채팅방 구독 요청 시 해당 경매 물품이 존재하는지 확인 ( chatRoomId == auctionItemId )
+     * 채팅방 구독 요청 시
+     * 해당 경매 물품이 존재하는지 확인 ( chatRoomId == auctionItemId )
+     * 접속자 목록에 유저Id, 세션Id 추가
      */
     private void handleSubscribe(StompHeaderAccessor stompHeaderAccessor) {
         log.info(":::: SUBSCRIBE 요청 감지 ::::");
@@ -102,6 +104,11 @@ public class StompHandler implements ChannelInterceptor {
             if (FALSE.equals(auctionItemService.hasAuctionItem(chatRoomId))) {
                 throw new CustomException(CHAT_ROOM_NOT_FOUND);
             }
+
+            stompHeaderAccessor.getSessionAttributes().put("chatRoomId", chatRoomId.toString());
+
+            chatRoomService.addSessionId(chatRoomId.toString(), userId.toString(),
+                stompHeaderAccessor.getSessionId());
 
             log.info("✅ SUBSCRIBE 성공: userId={}, chatRoomId={}", userId, chatRoomId);
         } catch (Exception e) {

--- a/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
+++ b/src/main/java/nbc/mushroom/config/websocket/StompHandler.java
@@ -129,9 +129,12 @@ public class StompHandler implements ChannelInterceptor {
             Long chatRoomId = StompUtil.getChatRoomId(stompHeaderAccessor, "/ws/pub");
             Long loginUserId = StompUtil.getUserId(stompHeaderAccessor);
 
-            boolean hasBid = TRUE.equals(bidService.hasBid(loginUserId, chatRoomId));
-
-            validateBidAndSessionAttributeError(stompHeaderAccessor, hasBid);
+            // '메시지' 전송에서만 실행
+            String destination = stompHeaderAccessor.getDestination();
+            if (destination.startsWith("/ws/pub/chats/")) {
+                boolean hasBid = TRUE.equals(bidService.hasBid(loginUserId, chatRoomId));
+                validateBidAndSessionAttributeError(stompHeaderAccessor, hasBid);
+            }
 
             log.info("✅ SEND 성공: userId={}, chatRoomId={}", loginUserId, chatRoomId);
         } catch (Exception e) {

--- a/src/main/java/nbc/mushroom/domain/chat/constant/RedisChatRoomKey.java
+++ b/src/main/java/nbc/mushroom/domain/chat/constant/RedisChatRoomKey.java
@@ -1,0 +1,22 @@
+package nbc.mushroom.domain.chat.constant;
+
+public class RedisChatRoomKey {
+
+    public static final String REDIS_CHAT_ROOM_KEY = "chatroom::";
+    public static final String REDIS_CHAT_ROOM_CONCURRENT_USERS_KEY = "::users";
+    private static final String REDIS_CHAT_ROOM_MESSAGE_KEY = "::message";
+
+    /**
+     * 동시 접속자 저장소 키
+     */
+    public static String getConcurrenUserStorageKey(String chatRoomId) {
+        return REDIS_CHAT_ROOM_KEY + chatRoomId + REDIS_CHAT_ROOM_CONCURRENT_USERS_KEY;
+    }
+
+    /**
+     * 메시지 저장소 키
+     */
+    public static String getMessageStorageKey(Long chatRoomId) {
+        return REDIS_CHAT_ROOM_KEY + chatRoomId.toString() + REDIS_CHAT_ROOM_MESSAGE_KEY;
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/chat/controller/ChatController.java
+++ b/src/main/java/nbc/mushroom/domain/chat/controller/ChatController.java
@@ -42,13 +42,6 @@ public class ChatController {
             User.fromAuthUser(authUser));
     }
 
-    @MessageMapping("/chatrooms/{chatRoomId}/users")
-    public void sendConcurrentUserList(
-        @DestinationVariable Long chatRoomId
-    ) {
-        chatRoomService.sendConcurrentUserList(chatRoomId);
-    }
-
     @GetMapping("/api/bids/chats/{chatRoomId}")
     public ResponseEntity<ApiResponse<List<ChatMessageRes>>> getChatHistory(
         @PathVariable Long chatRoomId

--- a/src/main/java/nbc/mushroom/domain/chat/controller/ChatController.java
+++ b/src/main/java/nbc/mushroom/domain/chat/controller/ChatController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.chat.dto.request.ChatMessageReq;
 import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
+import nbc.mushroom.domain.chat.service.ChatRoomService;
 import nbc.mushroom.domain.chat.service.ChatService;
 import nbc.mushroom.domain.common.annotation.Auth;
 import nbc.mushroom.domain.common.dto.ApiResponse;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     private final ChatService chatService;
+    private final ChatRoomService chatRoomService;
 
     @MessageMapping("/chats/{chatRoomId}")
     public ChatMessageRes sendChatMessage(
@@ -38,6 +40,13 @@ public class ChatController {
         log.info("Auth User ID : {} ", authUser.id());
         return chatService.sendChatMessage(chatRoomId, chatMessageReq, stompHeaderAccessor,
             User.fromAuthUser(authUser));
+    }
+
+    @MessageMapping("/chatrooms/{chatRoomId}/users")
+    public void sendConcurrentUserList(
+        @DestinationVariable Long chatRoomId
+    ) {
+        chatRoomService.sendConcurrentUserList(chatRoomId);
     }
 
     @GetMapping("/api/bids/chats/{chatRoomId}")

--- a/src/main/java/nbc/mushroom/domain/chat/dto/response/ConcurrentUserListRes.java
+++ b/src/main/java/nbc/mushroom/domain/chat/dto/response/ConcurrentUserListRes.java
@@ -1,0 +1,34 @@
+package nbc.mushroom.domain.chat.dto.response;
+
+import java.util.List;
+import nbc.mushroom.domain.user.entity.User;
+
+public record ConcurrentUserListRes(
+    Long chatRoomId,
+    Long concurrentUserCount,
+    List<UserInfoRes> userInfoRes
+) {
+
+    public static ConcurrentUserListRes from(Long chatRoomId, List<UserInfoRes> userInfoResList) {
+        return new ConcurrentUserListRes(
+            chatRoomId,
+            (long) userInfoResList.size(),
+            userInfoResList
+        );
+    }
+
+    public record UserInfoRes(
+        Long userId,
+        String nickname,
+        String imageUrl
+    ) {
+
+        public static UserInfoRes from(User user) {
+            return new UserInfoRes(
+                user.getId(),
+                user.getNickname(),
+                user.getImageUrl()
+            );
+        }
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/chat/entity/RedisSubMessage.java
+++ b/src/main/java/nbc/mushroom/domain/chat/entity/RedisSubMessage.java
@@ -1,0 +1,14 @@
+package nbc.mushroom.domain.chat.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RedisSubMessage {
+
+    private SubMessageType subMessageType;
+
+    private Object data;
+
+}

--- a/src/main/java/nbc/mushroom/domain/chat/entity/SubMessageType.java
+++ b/src/main/java/nbc/mushroom/domain/chat/entity/SubMessageType.java
@@ -1,6 +1,20 @@
 package nbc.mushroom.domain.chat.entity;
 
+import static nbc.mushroom.domain.common.exception.ExceptionType.SUB_MESSAGE_TYPE_NOT_FOUND;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import nbc.mushroom.domain.common.exception.CustomException;
+
 public enum SubMessageType {
     CHAT_MESSAGE,
     CONCURRENT_USER_LIST;
+
+    @JsonCreator // JSON → 객체 (역직렬화)
+    public static SubMessageType fromValue(String value) {
+        try {
+            return SubMessageType.valueOf(value);
+        } catch (RuntimeException e) {
+            throw new CustomException(SUB_MESSAGE_TYPE_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/entity/SubMessageType.java
+++ b/src/main/java/nbc/mushroom/domain/chat/entity/SubMessageType.java
@@ -1,0 +1,6 @@
+package nbc.mushroom.domain.chat.entity;
+
+public enum SubMessageType {
+    CHAT_MESSAGE,
+    CONCURRENT_USER_LIST;
+}

--- a/src/main/java/nbc/mushroom/domain/chat/event/ChatRoomCleanupEvent.java
+++ b/src/main/java/nbc/mushroom/domain/chat/event/ChatRoomCleanupEvent.java
@@ -1,0 +1,37 @@
+package nbc.mushroom.domain.chat.event;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nbc.mushroom.domain.chat.constant.RedisChatRoomKey;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatRoomCleanupEvent {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * 서버 종료가 감지되면 발생하는 이벤트
+     *
+     * 접속자 목록을 삭제함
+     */
+    @EventListener
+    public void cleanupConcurrentUsersOnShutdown(ContextClosedEvent event) {
+        log.info("애플리케이션 종료 감지 - 채팅방 세션 정리 시작...");
+
+        String key = RedisChatRoomKey.getConcurrenUserStorageKey("*");
+
+        // 특정 패턴을 가진 Redis 키 삭제 (예: chatroom::?::users)
+        Set<String> chatroomKeys = redisTemplate.keys(key);
+        if (chatroomKeys != null && !chatroomKeys.isEmpty()) {
+            redisTemplate.delete(chatroomKeys);
+        }
+        log.info("채팅방 세션 정리 완료 - {}개의 채팅방 삭제", chatroomKeys.size());
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/chat/event/ChatRoomEventListener.java
+++ b/src/main/java/nbc/mushroom/domain/chat/event/ChatRoomEventListener.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class ChatRoomCleanupEvent {
+public class ChatRoomEventListener {
 
     private final RedisTemplate<String, Object> redisTemplate;
 

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,45 @@
+package nbc.mushroom.domain.chat.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nbc.mushroom.domain.chat.constant.RedisChatRoomKey;
+import nbc.mushroom.domain.chat.dto.response.ConcurrentUserListRes.UserInfoRes;
+import nbc.mushroom.domain.user.entity.User;
+import nbc.mushroom.domain.user.repository.UserRepository;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final UserRepository userRepository;
+    private final RedisPublish redisPublish;
+
+    // Redis에서 현재 접속자 목록을 가져옴
+    private List<UserInfoRes> getConcurrentUsers(String chatRoomId) {
+        Set<Long> userIdSet = redisTemplate.opsForHash()
+            .keys(RedisChatRoomKey.getConcurrenUserStorageKey(chatRoomId))
+            .stream()
+            .map(key -> Long.valueOf(key.toString()))
+            .collect(Collectors.toSet());
+
+        if (userIdSet == null || userIdSet.isEmpty()) {
+            log.info("[채팅방 접속자 조회] chatRoomId={} - 현재 접속자 없음", chatRoomId);
+            return Collections.emptyList();
+        }
+
+        List<User> userList = userRepository.findAllById(userIdSet);
+        log.info("[채팅방 접속자 조회] chatRoomId={} - 접속자 수={}", chatRoomId, userList.size());
+
+        return userList.stream()
+            .map(UserInfoRes::from)
+            .toList();
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
@@ -47,6 +47,8 @@ public class ChatRoomService {
         );
 
         redisTemplate.opsForHash().put(key, userId, String.join(",", userSessionSet));
+
+        sendConcurrentUserList(Long.parseLong(chatRoomId));
     }
 
     /**

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.chat.constant.RedisChatRoomKey;
+import nbc.mushroom.domain.chat.dto.response.ConcurrentUserListRes;
 import nbc.mushroom.domain.chat.dto.response.ConcurrentUserListRes.UserInfoRes;
 import nbc.mushroom.domain.user.entity.User;
 import nbc.mushroom.domain.user.repository.UserRepository;
@@ -21,6 +22,15 @@ public class ChatRoomService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final UserRepository userRepository;
     private final RedisPublish redisPublish;
+
+    // 현재 접속자 목록 전송
+    public void sendConcurrentUserList(Long chatRoomId) {
+        List<UserInfoRes> userInfoResList = getConcurrentUsers(chatRoomId.toString());
+        ConcurrentUserListRes concurrentUserListRes = ConcurrentUserListRes.from(chatRoomId,
+            userInfoResList);
+
+        redisPublish.publishConcurrentUserList(concurrentUserListRes);
+    }
 
     // Redis에서 현재 접속자 목록을 가져옴
     private List<UserInfoRes> getConcurrentUsers(String chatRoomId) {

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisPublish.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisPublish.java
@@ -1,11 +1,16 @@
 package nbc.mushroom.domain.chat.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
+import nbc.mushroom.domain.chat.dto.response.ConcurrentUserListRes;
+import nbc.mushroom.domain.chat.entity.RedisSubMessage;
+import nbc.mushroom.domain.chat.entity.SubMessageType;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RedisPublish {
@@ -23,5 +28,14 @@ public class RedisPublish {
      */
     public void publish(ChatMessageRes chatMessageRes) {
         redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessageRes);
+    /**
+     * 현재 채팅방 접속자 목록 Redis 채널에 전송
+     */
+    public void publishConcurrentUserList(ConcurrentUserListRes concurrentUserListRes) {
+        RedisSubMessage redisSubMessage = new RedisSubMessage(SubMessageType.CONCURRENT_USER_LIST,
+            concurrentUserListRes);
+        redisTemplate.convertAndSend(channelTopic.getTopic(), redisSubMessage);
+        log.info("[Redis Publish] 채팅방 접속자 목록 발행 - chatRoomId={}, 접속자 수={}",
+            concurrentUserListRes.chatRoomId(), concurrentUserListRes.concurrentUserCount());
     }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisPublish.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisPublish.java
@@ -26,8 +26,14 @@ public class RedisPublish {
      *
      * @param chatMessageRes : 메시지 정보
      */
-    public void publish(ChatMessageRes chatMessageRes) {
-        redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessageRes);
+    public void publishChatMessage(ChatMessageRes chatMessageRes) {
+        RedisSubMessage redisSubMessage = new RedisSubMessage(SubMessageType.CHAT_MESSAGE,
+            chatMessageRes);
+        redisTemplate.convertAndSend(channelTopic.getTopic(), redisSubMessage);
+        log.info("[Redis Publish] 채팅 메시지 발행 - chatRoomId={}, sender={}, message={}",
+            chatMessageRes.chatRoomId(), chatMessageRes.nickname(), chatMessageRes.message());
+    }
+
     /**
      * 현재 채팅방 접속자 목록 Redis 채널에 전송
      */

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
@@ -1,8 +1,13 @@
 package nbc.mushroom.domain.chat.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.chat.dto.response.ChatMessageRes;
+import nbc.mushroom.domain.chat.dto.response.ConcurrentUserListRes;
+import nbc.mushroom.domain.chat.entity.SubMessageType;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -15,6 +20,7 @@ import org.springframework.stereotype.Service;
 public class RedisSubscriber implements MessageListener {
 
     private final RedisTemplate<String, Object> redisTemplate; // Redis에서 수신한 메시지의 역직렬화를 하기 위해
+    private final ObjectMapper objectMapper;
     private final SimpMessagingTemplate simpMessagingTemplate; // STOMP 메시지 전송을 위한 템플릿. WebSocket 연결된 클라이언트에게 메시지 보냄
 
     /**
@@ -23,13 +29,25 @@ public class RedisSubscriber implements MessageListener {
      * Redis의 Pub/Sub을 통해 발행된 메시지를 수신하면 호출됨
      * 해당 메시지를 WebSocket을 통해 클라이언트에게 전달
      *
+     * CHAT_MESSAGE - 메시지
+     * CONCURRENT_USER_LIST - 접속자 목록
+     *
+     * +) JsonNode : 계층형 key-value 구조
+     * key : RedisSubMessage 필드명
+     * value : 필드 값
+     *
      * @param message Redis에서 수신한 메시지 (바이트 배열로 전달됨)
      * @param pattern 메시지를 발행한 Redis 채널 패턴 (구독한 채널 정보)
      */
     @Override
     public void onMessage(Message message, byte[] pattern) {
-        ChatMessageRes chatMessageRes = (ChatMessageRes) redisTemplate.getValueSerializer()
-            .deserialize(message.getBody());
+        try {
+            String jsonString = new String(message.getBody(), StandardCharsets.UTF_8);
+            log.info("받은 원본 메시지: {}", jsonString);
+
+            JsonNode jsonNode = objectMapper.readTree(jsonString);
+            String subMessageTypeStr = jsonNode.get("subMessageType").asText();
+            String eventData = jsonNode.get("data").toString();
 
         log.info("[ChatRoomId: {}] [{}] {}: {} ( {} )",
             chatMessageRes.chatRoomId(),
@@ -38,6 +56,26 @@ public class RedisSubscriber implements MessageListener {
             chatMessageRes.message(),
             chatMessageRes.sendDateTime()
         );
+            SubMessageType subMessageType = SubMessageType.fromValue(subMessageTypeStr);
+
+            switch (subMessageType) {
+                case CHAT_MESSAGE:
+                    ChatMessageRes chatMessageRes = objectMapper.readValue(eventData,
+                        ChatMessageRes.class);
+                    handleChatMessage(chatMessageRes);
+                    break;
+                case CONCURRENT_USER_LIST:
+                    ConcurrentUserListRes concurrentUserListRes = objectMapper.readValue(eventData,
+                        ConcurrentUserListRes.class);
+                    handleUserList(concurrentUserListRes);
+                    break;
+                default:
+                    break;
+            }
+        } catch (Exception e) {
+            log.error("Redis 메시지 처리 중 오류 발생", e);
+        }
+    }
 
         // Redis에서 받은 메시지 WebSocket으로 전달 ( /ws/sub/chats/ -> 웹소켓 구독 경로 )
         simpMessagingTemplate.convertAndSend("/ws/sub/chats/" + chatMessageRes.chatRoomId(),

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
@@ -49,13 +49,6 @@ public class RedisSubscriber implements MessageListener {
             String subMessageTypeStr = jsonNode.get("subMessageType").asText();
             String eventData = jsonNode.get("data").toString();
 
-        log.info("[ChatRoomId: {}] [{}] {}: {} ( {} )",
-            chatMessageRes.chatRoomId(),
-            chatMessageRes.messageType(),
-            chatMessageRes.nickname(),
-            chatMessageRes.message(),
-            chatMessageRes.sendDateTime()
-        );
             SubMessageType subMessageType = SubMessageType.fromValue(subMessageTypeStr);
 
             switch (subMessageType) {
@@ -77,8 +70,17 @@ public class RedisSubscriber implements MessageListener {
         }
     }
 
+    private void handleChatMessage(ChatMessageRes chatMessageRes) {
+        log.info("[Redis Subscribe] 채팅 메시지 수신 - chatRoomId={}, sender={}, message={}",
+            chatMessageRes.chatRoomId(), chatMessageRes.nickname(), chatMessageRes.message());
+
         // Redis에서 받은 메시지 WebSocket으로 전달 ( /ws/sub/chats/ -> 웹소켓 구독 경로 )
         simpMessagingTemplate.convertAndSend("/ws/sub/chats/" + chatMessageRes.chatRoomId(),
             chatMessageRes);
+
+        log.info("[WebSocket Send] 채팅 메시지 전송 - chatRoomId={}, sender={}, message={}",
+            chatMessageRes.chatRoomId(), chatMessageRes.nickname(), chatMessageRes.message());
+    }
+
     }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/RedisSubscriber.java
@@ -60,7 +60,7 @@ public class RedisSubscriber implements MessageListener {
                 case CONCURRENT_USER_LIST:
                     ConcurrentUserListRes concurrentUserListRes = objectMapper.readValue(eventData,
                         ConcurrentUserListRes.class);
-                    handleUserList(concurrentUserListRes);
+                    handleConcurrentUserList(concurrentUserListRes);
                     break;
                 default:
                     break;
@@ -82,5 +82,15 @@ public class RedisSubscriber implements MessageListener {
             chatMessageRes.chatRoomId(), chatMessageRes.nickname(), chatMessageRes.message());
     }
 
+    private void handleConcurrentUserList(ConcurrentUserListRes concurrentUserListRes) {
+        log.info("[Redis Subscribe] 채팅방 접속자 목록 수신 - chatRoomId={}, 접속자 수={}",
+            concurrentUserListRes.chatRoomId(), concurrentUserListRes.concurrentUserCount());
+
+        simpMessagingTemplate.convertAndSend(
+            "/ws/sub/chatrooms/" + concurrentUserListRes.chatRoomId() + "/users",
+            concurrentUserListRes);
+
+        log.info("[WebSocket Send] 채팅방 접속자 목록 전송 - chatRoomId={}, 접속자 수={}",
+            concurrentUserListRes.chatRoomId(), concurrentUserListRes.concurrentUserCount());
     }
 }

--- a/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
+++ b/src/main/java/nbc/mushroom/domain/common/exception/ExceptionType.java
@@ -67,6 +67,7 @@ public enum ExceptionType {
     INVALID_CHAT_ROOM_PATH(HttpStatus.BAD_REQUEST, "C01", "유효하지 않은 채팅방 경로입니다."),
     BIDDING_REQUIRED(HttpStatus.FORBIDDEN, "C02", "메시지 전송 권한이 없습니다. 해당 경매물품에 대한 입찰 내역이 필요합니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "C03", "해당 채팅방을 찾을 수 없습니다."),
+    SUB_MESSAGE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "C04", "일치하는 SubMessage 타입을 찾을 수 없습니다."),
 
     // Review
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "R01", "해당 판매자에 대한 리뷰를 이미 작성하였습니다."),

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -12,20 +12,67 @@
       margin: 20px;
     }
 
-    /* 메시지 컨테이너 Flex 설정 */
-    #messages {
+    /* ✅ 채팅창과 접속자 목록을 가로 배치 */
+    #container {
       display: flex;
-      flex-direction: column;
-      list-style: none;
-      padding: 0;
+      flex-direction: row; /* 가로 정렬 */
+      justify-content: space-between;
+      align-items: flex-start;
+      width: 100%;
+      max-width: 1200px; /* 최대 너비 설정 */
+      margin: 0 auto; /* 가운데 정렬 */
     }
 
-    #messages li {
+    /* ✅ 메시지 목록을 화면 대부분 차지하도록 설정 */
+    #messagesContainer {
+      flex-grow: 1; /* 남는 공간을 최대한 차지 */
+      padding-right: 20px;
+    }
+
+    /* ✅ 접속자 목록 UI 정리 */
+    #userListContainer {
+      width: 250px; /* 접속자 목록 크기 조절 */
+      padding: 10px;
+      border: 1px solid #ccc;
+      border-radius: 5px;
+      background-color: #f9f9f9;
+      text-align: center; /* 제목 가운데 정렬 */
+    }
+
+    /* ✅ 접속자 수를 목록 위로 정렬 */
+    #userCount {
+      display: block; /* 목록 위에 표시 */
+      font-size: 16px;
+      font-weight: bold;
       margin-bottom: 10px;
-      padding: 5px 10px;
-      border-radius: 8px;
-      max-width: 70%;
-      word-wrap: break-word;
+    }
+
+    /* ✅ 접속자 목록 스타일 */
+    #userList {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+
+    /* ✅ 개별 사용자 항목 */
+    .user-item {
+      display: flex;
+      align-items: center;
+      padding: 5px;
+      border-bottom: 1px solid #ddd;
+      text-align: left; /* 사용자 이름 왼쪽 정렬 */
+    }
+
+    .user-item img {
+      max-width: 40px;
+      max-height: 40px;
+      border-radius: 50%;
+      margin-right: 10px;
+    }
+
+    .user-item span {
+      font-weight: bold;
+      color: #333;
     }
 
     /* 내 메시지 (오른쪽 정렬, 배경색) */
@@ -66,23 +113,39 @@
   </style>
 </head>
 <body>
-<h2>STOMP 채팅 테스트</h2>
-<label for="tokenInput">토큰:</label>
-<input type="text" id="tokenInput" placeholder="토큰 입력">
-<button onclick="connect()">🔗 연결</button> <!-- ✅ 연결 버튼 추가 -->
-<br><br>
-<label for="chatRoomId">채팅방 ID:</label>
-<input type="text" id="chatRoomId" value="1" size="3">
-<br><br>
-<label for="messageInput">메시지:</label>
-<input type="text" id="messageInput" placeholder="메시지를 입력하세요">
-<button id="sendButton" onclick="sendMessage()" disabled>💬 전송</button> <!-- ✅ 초기에는 비활성화 -->
-<hr>
-<ul id="messages"></ul>
+<!-- ✅ 채팅창 & 접속자 목록을 가로 배치하는 컨테이너 -->
+<div id="container">
+  <!-- ✅ 메시지 영역 -->
+  <div id="messagesContainer">
+    <h2>STOMP 채팅 테스트</h2>
+    <label for="tokenInput">토큰:</label>
+    <input type="text" id="tokenInput" placeholder="토큰 입력">
+    <button onclick="connect()">🔗 연결</button>
+    <br><br>
+    <label for="chatRoomId">채팅방 ID:</label>
+    <input type="text" id="chatRoomId" value="1" size="3">
+    <br><br>
+    <label for="messageInput">메시지:</label>
+    <input type="text" id="messageInput" placeholder="메시지를 입력하세요">
+    <button id="sendButton" onclick="sendMessage()" disabled>💬 전송</button>
+    <hr>
+    <ul id="messages"></ul>
+  </div>
+
+  <!-- ✅ 현재 접속자 목록 (오른쪽 배치) -->
+  <div id="userListContainer">
+    <h3 id="userCount">현재 접속자: 0명</h3>
+    <h3>현재 접속자 목록</h3>
+    <ul id="userList">
+      <li>현재 접속자가 없습니다.</li>
+    </ul>
+  </div>
+</div>
 
 <script>
   let stompClient = null;
   let subscription = null;
+  let userListSubscription = null;
   let myUserId = null;
   let lastDateKey = null;  // 마지막으로 표시한 날짜 (YYYY-MM-DD)
 
@@ -119,13 +182,23 @@
       console.log('✅ STOMP 연결 성공:', frame);
 
       const chatRoomId = document.getElementById("chatRoomId").value;
-      // 이미 구독이 존재하면 unsubscribe (중복 방지)
+
+      // ✅ 기존 구독 해제 후 다시 구독
       if (subscription) {
         subscription.unsubscribe();
       }
+      if (userListSubscription) {
+        userListSubscription.unsubscribe();
+      }
+
       subscription = stompClient.subscribe('/ws/sub/chats/' + chatRoomId,
           handleSubscriptionMessage);
       console.log(`✅ 메시지 구독 성공: /ws/sub/chats/${chatRoomId}`);
+
+      // ✅ 사용자 목록 구독 (현재 접속자 목록 수신)
+      userListSubscription = stompClient.subscribe('/ws/sub/chatrooms/' + chatRoomId + '/users',
+          handleUserListUpdate);
+      console.log(`✅ 사용자 목록 구독 성공: /ws/sub/chatrooms/${chatRoomId}/users`);
 
       // STOMP 연결 완료 후 전송 버튼 활성화
       document.getElementById("sendButton").disabled = false;
@@ -133,9 +206,60 @@
       // ✅ 이전 채팅 내역 불러오기 (REST API 호출)
       fetchChatHistory(chatRoomId);
 
+      // ✅ 서버에 현재 접속자 목록 요청
+      stompClient.send(`/ws/pub/chatrooms/${chatRoomId}/users`, {}, {});
+
     }, function (error) {
       console.error('🚨 STOMP 연결 오류:', error);
       alert("STOMP 연결에 실패했습니다. 서버 상태를 확인하세요.");
+    });
+  }
+
+  /**
+   * handleUserListUpdate: 서버에서 접속자 목록을 수신하여 업데이트
+   */
+  function handleUserListUpdate(message) {
+    const data = JSON.parse(message.body);
+    console.log("✅ 현재 접속자 목록 수신:", data);
+    updateUserList(data.userInfoRes, data.currentUserCount);
+  }
+
+  /**
+   * updateUserList: 화면의 접속자 목록을 갱신
+   */
+  function updateUserList(userList, currentUserCount) {
+    const userListDiv = document.getElementById("userList"); // ✅ 접속자 목록
+    const userCountElement = document.getElementById("userCount"); // ✅ 접속자 수
+    userListDiv.innerHTML = "";
+
+    // ✅ 접속자 수 업데이트
+    userCountElement.textContent = `현재 접속자: ${currentUserCount}명`;
+
+    // ✅ 목록 초기화
+    userListDiv.innerHTML = "";
+
+    if (!userList || userList.length === 0) {
+      userListDiv.innerHTML = "현재 접속자가 없습니다.";
+      return;
+    }
+
+    userList.forEach(user => {
+      const userItem = document.createElement("li");
+      userItem.classList.add("user-item");
+
+      const userImage = document.createElement("img");
+      userImage.src = user.imageUrl
+          || "https://yeim-vpc-bucket-240130.s3.ap-northeast-2.amazonaws.com/public/12b545cf-2687-46e6-8c4d-aecef88d762b.JPG"; // 기본 이미지
+
+      const userName = document.createElement("span");
+      userName.textContent = user.nickname;
+
+      userItem.appendChild(userImage);
+      userItem.appendChild(userName);
+
+      console.log(`✅ 접속자 추가됨: ${user.nickname}`); // 🔍 디버깅용 로그 추가
+
+      userListDiv.appendChild(userItem);
     });
   }
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -206,9 +206,6 @@
       // ✅ 이전 채팅 내역 불러오기 (REST API 호출)
       fetchChatHistory(chatRoomId);
 
-      // ✅ 서버에 현재 접속자 목록 요청
-      stompClient.send(`/ws/pub/chatrooms/${chatRoomId}/users`, {}, {});
-
     }, function (error) {
       console.error('🚨 STOMP 연결 오류:', error);
       alert("STOMP 연결에 실패했습니다. 서버 상태를 확인하세요.");

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -221,7 +221,7 @@
   function handleUserListUpdate(message) {
     const data = JSON.parse(message.body);
     console.log("✅ 현재 접속자 목록 수신:", data);
-    updateUserList(data.userInfoRes, data.currentUserCount);
+    updateUserList(data.userInfoRes, data.concurrentUserCount);
   }
 
   /**


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #134

## 📝 요약

> 무엇을 했는지 요약

- 현재 접속자 목록을 구현했습니다
- Redis 템플릿 설정을 고쳤습니다 (특정 클래스에서 Object 클래스로 바꿔 범용성을 증가시켰습니다.)
- 서버가 종료되면 이벤트를 발생시켜 접속자 목록이 저장된 저장소를 삭제시키도록 하였습니다. 

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

- 채팅 메시지 저장소 이름이 바꼈습니다. 그에 따라 기존에 저장된 채팅 메시지들이 불러와지지 않을 것으로 예상됩니다.
   - 변경 전 : chatroom:채팅방ID
   - 변경 후 : chatroom::채팅방ID::message
  
- 커밋이 많아요.. 감사합니다
- 메서드 이름이나 클래스 이름(특히 Event 클래스,,)이 길고 작명이 어려웠습니다.. 최대한 간결하지만 어떤 동작을 하는지는 담겼으면 좋겠다 싶었는데 두 마리 토끼를 다 잡진 못한거 같아요. 더 좋은 이름이 있다면 추천 부탁드립니다.

- 저장소 구조
  - Key: chatroom::채팅방id::users 
     Field: userId
      Value: sessionId 들

- 구현 영상

https://github.com/user-attachments/assets/79264f4c-f207-4a93-850e-3a5dcb3acfa0


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
