### PR TITLE
[Bug(bid)] 상태 변경되지 않는 입찰이 생기지 않도록 로직 변경, 상태 변경 로직 최적화

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -69,7 +69,7 @@ public class AuctionItemStatusService {
             succedBid.succeed();
 
             // 최고가 아닌 Bid들을 fail 처리
-            bidRepository.findPotentiallyFailedBidsByAuctionItem(auctionItem)
+            bidRepository.findPotentiallyFailedBidsByAuctionItem(auctionItem, succedBid)
                 .forEach(Bid::fail);
         }
     }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepository.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepository.java
@@ -1,8 +1,15 @@
 package nbc.mushroom.domain.bid.repository;
 
+import java.util.List;
+import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.bid.entity.BiddingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BidRepository extends JpaRepository<Bid, Long>, BidRepositoryCustom {
 
+    List<Bid> findBidsByAuctionItemAndBiddingStatus(
+        AuctionItem auctionItem,
+        BiddingStatus biddingStatus
+    );
 }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -17,7 +17,7 @@ public interface BidRepositoryCustom {
 
     Bid findPotentiallySucceededBidByAuctionItem(AuctionItem auctionItem);
 
-    List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem);
+    List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem, Bid succedBid);
 
     Boolean existsBidByAuctionItem(AuctionItem auctionItem);
 

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryCustom.java
@@ -1,6 +1,5 @@
 package nbc.mushroom.domain.bid.repository;
 
-import java.util.List;
 import java.util.Optional;
 import nbc.mushroom.domain.auction_item.dto.response.AuctionItemBidInfoRes;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
@@ -16,8 +15,6 @@ public interface BidRepositoryCustom {
     Optional<Bid> findBidByUserAndAuctionItem(User bidder, AuctionItem auctionItem);
 
     Bid findPotentiallySucceededBidByAuctionItem(AuctionItem auctionItem);
-
-    List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem, Bid succedBid);
 
     Boolean existsBidByAuctionItem(AuctionItem auctionItem);
 

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -51,7 +51,10 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
         return queryFactory
             .select(bid)
             .from(bid)
-            .where(bid.auctionItem.eq(auctionItem))
+            .where(
+                bid.auctionItem.eq(auctionItem),
+                bid.biddingStatus.eq(BiddingStatus.BIDDING)
+            )
             .orderBy(bid.biddingPrice.desc())
             .limit(1)
             .fetchOne();
@@ -66,7 +69,8 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
             .from(bid)
             .where(
                 bid.auctionItem.eq(auctionItem),
-                bid.ne(succeedBid)
+                bid.ne(succeedBid),
+                bid.biddingStatus.eq(BiddingStatus.BIDDING)
             )
             .fetch();
     }

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -60,21 +60,6 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
             .fetchOne();
     }
 
-
-    @Override
-    public List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem,
-        Bid succeedBid) {
-        return queryFactory
-            .select(bid)
-            .from(bid)
-            .where(
-                bid.auctionItem.eq(auctionItem),
-                bid.ne(succeedBid),
-                bid.biddingStatus.eq(BiddingStatus.BIDDING)
-            )
-            .fetch();
-    }
-
     @Override
     public Boolean existsBidByAuctionItem(AuctionItem auctionItem) {
         return queryFactory

--- a/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
+++ b/src/main/java/nbc/mushroom/domain/bid/repository/BidRepositoryImpl.java
@@ -8,7 +8,6 @@ import static nbc.mushroom.domain.user.entity.QUser.user;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -20,7 +19,6 @@ import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.bid.dto.response.BidInfoRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
-import nbc.mushroom.domain.bid.entity.QBid;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -61,20 +59,14 @@ public class BidRepositoryImpl implements BidRepositoryCustom {
 
 
     @Override
-    public List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem) {
-
-        QBid subBid = new QBid("subBid");
-
+    public List<Bid> findPotentiallyFailedBidsByAuctionItem(AuctionItem auctionItem,
+        Bid succeedBid) {
         return queryFactory
             .select(bid)
             .from(bid)
             .where(
                 bid.auctionItem.eq(auctionItem),
-                bid.biddingPrice.ne(JPAExpressions
-                    .select(subBid.biddingPrice.max())
-                    .from(subBid)
-                    .where(subBid.auctionItem.eq(auctionItem))
-                )
+                bid.ne(succeedBid)
             )
             .fetch();
     }


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #139 

## 📝 요약

<img width="730" alt="419335553-1359efac-e657-418b-bcec-709e8d4941c5" src="https://github.com/user-attachments/assets/fc92ad21-21ce-44a8-8acb-23ccb7b37e7f" />

동시성이 터지는거 자체가 문제지만, 성공이외에는 모두 FAILED가 되어야 하는 상황인데 뭔가 이상한거 같아서, 우선 이 부분만 먼저 해결했습니다.

## 💬 참고사항


### 1: 성공 입찰을 기준으로 찾는 방식으로 변경

<img width="470" alt="스크린샷 2025-03-05 오후 4 17 25" src="https://github.com/user-attachments/assets/269e07d0-928a-4250-b440-19120bda687c" />

이전에는 실패한 입찰들을 가져올 때 서브쿼리를 통해 최고가를 계산해서 최고가가 아닌 입찰들을 가져오는 방식인데, 

<img width="731" alt="스크린샷 2025-03-05 오후 3 37 25" src="https://github.com/user-attachments/assets/24f6d9a7-5df6-4855-8629-110637be163c" />

이미 succeed bid를 가져오고 있습니다. 그래서 이 SucceedBid를 넘겨받아 이 bid외에 모든 입찰 내역을 가져오도록 했고, 서브쿼리를 사용하지 않아 성능적으로도 개선되었습니다. [`15b17a60`](https://github.com/mushroom-4/mushroom-be/commit/15b17a6068665df1fbc190788fcddd563c0c7de2)

### 2: 다른 상태의 입찰들도 불러오는 문제 해결

여기에 또 문제가 있었는데요, CANCEL상태의 입찰을 실패로 돌리려 하는 겁니다. 만약에 모든 입찰 내역 중에 하나라도 CANCEL이 있다면 에러가 나면서 다른 입찰들을 FAIL로 돌리려는 로직이 중단됩니다.

그리고 이거는 성공부분도 마찬가지구요. (아마 입찰 취소라는 정책이 이 로직이 만들어지고 난 이후에 생긴거라 발생한 문제 같습니다...! 이래서 테스트 코드가 필요하군요.... 깨달았습니다. 이렇게 인사이트를 하나 더 얻어가네요)

<img width="723" alt="스크린샷 2025-03-05 오후 4 41 27" src="https://github.com/user-attachments/assets/258f0c3e-4832-49b1-89eb-24b9b6e330a0" />

그래서 Bidding 중인 애들만 가져오도록 변경했습니다. [`049088d3`](https://github.com/mushroom-4/mushroom-be/commit/049088d33aafb446e58991467237bdf8c34792bf)

### 3: DB조회 3번 -> 1번

현재 입찰 내역을 변경하는 기능을 위해서 한 AuctionItem당 DB조회를 세번을 하고 있습니다.

<img width="500" alt="스크린샷 2025-03-05 오후 4 54 28" src="https://github.com/user-attachments/assets/30c16fde-358d-45da-8d2e-12978c4dfa1c" />

쿼리 1번으로 해결할 수 있을거 같아서 수정했습니다.

<img width="500" alt="스크린샷 2025-03-05 오후 5 06 59" src="https://github.com/user-attachments/assets/58eea700-69ea-4e85-86e6-90c36ec75bd1" />

[`239c72c3`](https://github.com/mushroom-4/mushroom-be/commit/239c72c393f9f2ab288ff4032621f58b43c7eacb)

코드가 더 길어져 보이는 건 착시 현상입니다.

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
