### PR TITLE
[Feature(chat)] 채팅 메시지 저장소 만료 시간 설정

### DIFF
--- a/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
+++ b/src/main/java/nbc/mushroom/domain/auction_item/service/AuctionItemStatusService.java
@@ -14,6 +14,7 @@ import nbc.mushroom.domain.auction_item.repository.AuctionItemRepository;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
 import nbc.mushroom.domain.bid.repository.BidRepository;
+import nbc.mushroom.domain.chat.service.ChatRoomService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ public class AuctionItemStatusService {
 
     private final AuctionItemRepository auctionItemRepository;
     private final BidRepository bidRepository;
+    private final ChatRoomService chatRoomService;
 
     @Scheduled(cron = "0 */1 * * * *") // 매 5분마다 (정각 기준)
     @Transactional(readOnly = false)
@@ -85,6 +87,10 @@ public class AuctionItemStatusService {
             auctionItem.complete();
             log.info("auction ID : {}", auctionItem.getId().toString());
             log.info("auction Status : {}", auctionItem.getStatus());
+
+            // 채팅방 메시지 기록 만료 시간 설정
+            chatRoomService.setChatRoomStorageTTL(auctionItem.getId());
+
         }
     }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
@@ -122,6 +122,12 @@ public class ChatRoomService {
      */
     public void setChatRoomStorageTTL(Long chatRoomId) {
         String key = RedisChatRoomKey.getMessageStorageKey(chatRoomId);
+
+        Boolean hasKey = redisTemplate.hasKey(key);
+        if (!hasKey) {
+            return;
+        }
+
         Duration ttl = Duration.ofDays(7);
 
         redisTemplate.expire(key, ttl);

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatRoomService.java
@@ -1,5 +1,7 @@
 package nbc.mushroom.domain.chat.service;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -113,5 +115,21 @@ public class ChatRoomService {
         return userList.stream()
             .map(UserInfoRes::from)
             .toList();
+    }
+
+    /**
+     * 채팅방 메시지 저장소 만료 시간 설정
+     */
+    public void setChatRoomStorageTTL(Long chatRoomId) {
+        String key = RedisChatRoomKey.getMessageStorageKey(chatRoomId);
+        Duration ttl = Duration.ofDays(7);
+
+        redisTemplate.expire(key, ttl);
+
+        Long expireSecond = redisTemplate.getExpire(key);
+        LocalDateTime expirationTime = LocalDateTime.now().plusSeconds(expireSecond);
+
+        log.info("[채팅방 TTL 설정] chatRoomId={}, Redis Storage Key={}, 만료 예정 시간={}",
+            chatRoomId, key, expirationTime);
     }
 }

--- a/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
+++ b/src/main/java/nbc/mushroom/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package nbc.mushroom.domain.chat.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -25,6 +26,7 @@ public class ChatService {
 
     private final RedisPublish redisPublish;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     /**
      * 클라이언트가 보낸 메시지를 Redis에 저장하고 전송
@@ -149,7 +151,7 @@ public class ChatService {
         }
 
         return chatMessageList.stream()
-            .map(o -> (ChatMessageRes) o) // Object → ChatMessage 변환
+            .map(o -> objectMapper.convertValue(o, ChatMessageRes.class)) // Object → ChatMessage 변환
             .toList(); // 최종 List<ChatMessageRes> 반환
     }
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -54,6 +54,19 @@
       margin: 0;
     }
 
+    /* ✅ 메시지 목록 스타일 개선 */
+    #messages {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      width: 100%;
+      overflow-y: auto; /* 스크롤 가능하도록 설정 */
+      max-height: 400px; /* 필요 시 최대 높이 지정 가능 */
+    }
+
     /* ✅ 개별 사용자 항목 */
     .user-item {
       display: flex;
@@ -75,6 +88,17 @@
       color: #333;
     }
 
+    /* 개별 메시지 스타일 */
+    .message-item {
+      display: flex;
+      max-width: 70%;
+      padding: 10px;
+      margin: 5px;
+      border-radius: 15px;
+      word-break: break-word;
+      white-space: pre-wrap;
+    }
+
     /* 내 메시지 (오른쪽 정렬, 배경색) */
     .my-message {
       align-self: flex-end;
@@ -91,16 +115,22 @@
       background-color: #f1f1f1; /* 예시 배경색 추가 */
     }
 
-    /* 날짜 헤더 스타일 */
+    /* ✅ 날짜 헤더 스타일 개선 */
     .date-header {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      font-size: 14px;
       font-weight: bold;
-      margin: 10px 0;
-      background-color: #fff;
-      color: #888;
-      border: 1px solid #ccc;
-      border-radius: 4px;
+      color: #666;
+      margin: 15px 0 10px 0; /* 날짜 헤더의 여백 조정 */
+      padding: 5px 0;
+      background-color: #f5f5f5;
+      border-radius: 5px;
+      text-align: center;
     }
+
 
     /* 둥근 이미지 예시 */
     .chat-img {
@@ -310,8 +340,6 @@
    */
   function appendMessage(msg) {
     const messagesList = document.getElementById("messages");
-    // 실제 메시지 표시
-    const messageElement = document.createElement('li');
 
     // 날짜 키 추출 (YYYY-MM-DD)
     const dateKey = formatDateKey(msg.sendDateTime);
@@ -329,13 +357,18 @@
     // 내 메시지 여부: myUserId와 msg.senderId 비교
     const isMyMessage = myUserId !== null && msg.senderId === myUserId;
 
+    // 실제 메시지 표시
+    const messageElement = document.createElement("div");
+    messageElement.classList.add("message-item");
+    messageElement.classList.add(isMyMessage ? "my-message" : "other-message");
+
     // 메시지 텍스트 구성
     messageElement.textContent = `[${timeString}] ${msg.nickname || '익명'}: ${msg.message}`;
 
-    // 내 메시지와 타 메시지 구분 (CSS 클래스 적용)
-    messageElement.className = isMyMessage ? "my-message" : "other-message";
-
     messagesList.appendChild(messageElement);
+
+    // ✅ 스크롤을 최신 메시지로 이동
+    messagesList.scrollTop = messagesList.scrollHeight;
     console.log("메시지 추가:", msg);
   }
 


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #141

## 📝 요약

> 무엇을 했는지 요약

- 경매가 종료되면 그 이후부터 7일 동안만 유지할 수 있도록 TTL 설정을 했습니다.
- 이전 채팅 메시지 내역을 Redis에서 불러오는 과정(역직렬화)을 더 안전하게 진행될 수 있도록 ObjectMapper 사용을 추가했습니다. 

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
