### PR TITLE
[Feature(payment)] 결제와 비즈니스 로직 트랜잭션 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,17 +14,14 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-2
-      - name: Login to Public ECR
-        env:
-          AWS_REGION: us-east-1
-        run: |
-          aws ecr-public get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin public.ecr.aws/p5g9k3t8/mutt-api
       - name: Build and Push Docker image
         env:
+          AWS_REGION: us-east-1
           ECR_REGISTRY: public.ecr.aws
           ECR_REPOSITORY: p5g9k3t8/mutt-api
           IMAGE_TAG: latest
         run: |
+          aws ecr-public get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin public.ecr.aws/p5g9k3t8/mutt-api
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       - name: Deploy to EC2

--- a/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
+++ b/src/main/java/nbc/mushroom/domain/bid/entity/Bid.java
@@ -1,6 +1,7 @@
 package nbc.mushroom.domain.bid.entity;
 
 import static nbc.mushroom.domain.bid.entity.BiddingStatus.BIDDING;
+import static nbc.mushroom.domain.bid.entity.BiddingStatus.PAYMENT_COMPLETED;
 import static nbc.mushroom.domain.bid.entity.BiddingStatus.SUCCEED;
 import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_BID_STATUS;
 import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_PAYMENT_AMOUNT;
@@ -98,5 +99,12 @@ public class Bid extends Timestamped {
             throw new CustomException(INVALID_BID_STATUS);
         }
         this.biddingStatus = BiddingStatus.PAYMENT_COMPLETED;
+    }
+
+    public void paymentCancel() {
+        if (this.biddingStatus != PAYMENT_COMPLETED) {
+            throw new CustomException(INVALID_BID_STATUS);
+        }
+        this.biddingStatus = SUCCEED;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -66,6 +66,14 @@ public class BidService {
         bid.paymentComplete(paymentReq.amount());
     }
 
+    @Transactional
+    public void paymentCancel(PaymentReq paymentReq) {
+        Long bidId = Long.valueOf(paymentReq.orderId().substring(20));
+        Bid bid = bidRepository.findById(bidId)
+            .orElseThrow(() -> new CustomException(BID_NOT_FOUND));
+        bid.paymentCancel();
+    }
+
     private void validateBidCancellation(User loginUser, Bid bid) {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/BidService.java
@@ -5,6 +5,8 @@ import static nbc.mushroom.domain.bid.entity.BiddingStatus.CANCELED;
 import static nbc.mushroom.domain.common.exception.ExceptionType.BID_CANCELLATION_LIMIT_EXCEEDED;
 import static nbc.mushroom.domain.common.exception.ExceptionType.BID_CANNOT_CANCEL_NON_BIDDING;
 import static nbc.mushroom.domain.common.exception.ExceptionType.BID_CANNOT_CANCEL_WITHIN_24HOURS;
+import static nbc.mushroom.domain.common.exception.ExceptionType.BID_NOT_FOUND;
+import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_PAYMENT_USER;
 
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +14,9 @@ import nbc.mushroom.domain.bid.dto.response.BidInfoRes;
 import nbc.mushroom.domain.bid.dto.response.BidRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
+import nbc.mushroom.domain.common.dto.AuthUser;
 import nbc.mushroom.domain.common.exception.CustomException;
+import nbc.mushroom.domain.payment.dto.request.PaymentReq;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -46,6 +50,20 @@ public class BidService {
 
     public Boolean hasBid(Long bidderId, Long auctionItemId) {
         return bidRepository.existBidByBidderIdAndAuctionItemId(bidderId, auctionItemId);
+    }
+
+    @Transactional
+    public void paymentConfirm(AuthUser authUser, PaymentReq paymentReq) {
+        User user = User.fromAuthUser(authUser);
+        Long bidId = Long.valueOf(paymentReq.orderId().substring(20));
+        Bid bid = bidRepository.findById(bidId)
+            .orElseThrow(() -> new CustomException(BID_NOT_FOUND));
+
+        if (!user.getId().equals(bid.getBidder().getId())) {
+            throw new CustomException(INVALID_PAYMENT_USER);
+        }
+
+        bid.paymentComplete(paymentReq.amount());
     }
 
     private void validateBidCancellation(User loginUser, Bid bid) {

--- a/src/main/java/nbc/mushroom/domain/payment/controller/PaymentController.java
+++ b/src/main/java/nbc/mushroom/domain/payment/controller/PaymentController.java
@@ -7,7 +7,7 @@ import nbc.mushroom.domain.common.dto.ApiResponse;
 import nbc.mushroom.domain.common.dto.AuthUser;
 import nbc.mushroom.domain.payment.dto.request.PaymentReq;
 import nbc.mushroom.domain.payment.dto.response.PaymentRes;
-import nbc.mushroom.domain.payment.service.PaymentService;
+import nbc.mushroom.domain.payment.service.PaymentFacade;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/payments")
 public class PaymentController {
 
-    private final PaymentService paymentService;
+    private final PaymentFacade paymentFacade;
 
     @PostMapping("/confirm")
     public ResponseEntity<ApiResponse<PaymentRes>> confirmPayment(
         @Auth AuthUser authUser,
         @Valid @RequestBody PaymentReq paymentReq
     ) {
-        PaymentRes paymentRes = paymentService.confirmPayment(authUser, paymentReq);
+        PaymentRes paymentRes = paymentFacade.confirmPayment(authUser, paymentReq);
 
         return ResponseEntity.status(HttpStatus.OK)
             .body(ApiResponse.success("결제가 정상적으로 완료되었습니다.", paymentRes));

--- a/src/main/java/nbc/mushroom/domain/payment/service/PaymentFacade.java
+++ b/src/main/java/nbc/mushroom/domain/payment/service/PaymentFacade.java
@@ -15,14 +15,12 @@ public class PaymentFacade {
     private final BidService bidService;
 
     public PaymentRes confirmPayment(AuthUser authUser, PaymentReq paymentReq) {
-        PaymentRes paymentRes = PaymentRes.from(paymentService.sendPayment(paymentReq));
+        bidService.paymentConfirm(authUser, paymentReq);
         try {
-            bidService.paymentConfirm(authUser, paymentReq);
+            return PaymentRes.from(paymentService.sendPayment(paymentReq));
         } catch (Exception e) {
-            paymentService.cancelPayment(paymentRes.paymentKey(), e.getMessage(),
-                paymentRes.amount());
+            bidService.paymentCancel(paymentReq);
             throw e;
         }
-        return paymentRes;
     }
 }

--- a/src/main/java/nbc/mushroom/domain/payment/service/PaymentFacade.java
+++ b/src/main/java/nbc/mushroom/domain/payment/service/PaymentFacade.java
@@ -1,0 +1,28 @@
+package nbc.mushroom.domain.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.service.BidService;
+import nbc.mushroom.domain.common.dto.AuthUser;
+import nbc.mushroom.domain.payment.dto.request.PaymentReq;
+import nbc.mushroom.domain.payment.dto.response.PaymentRes;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+    private final PaymentService paymentService;
+    private final BidService bidService;
+
+    public PaymentRes confirmPayment(AuthUser authUser, PaymentReq paymentReq) {
+        PaymentRes paymentRes = PaymentRes.from(paymentService.sendPayment(paymentReq));
+        try {
+            bidService.paymentConfirm(authUser, paymentReq);
+        } catch (Exception e) {
+            paymentService.cancelPayment(paymentRes.paymentKey(), e.getMessage(),
+                paymentRes.amount());
+            throw e;
+        }
+        return paymentRes;
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/payment/service/PaymentService.java
+++ b/src/main/java/nbc/mushroom/domain/payment/service/PaymentService.java
@@ -1,7 +1,5 @@
 package nbc.mushroom.domain.payment.service;
 
-import static nbc.mushroom.domain.common.exception.ExceptionType.BID_NOT_FOUND;
-import static nbc.mushroom.domain.common.exception.ExceptionType.INVALID_PAYMENT_USER;
 import static nbc.mushroom.domain.common.exception.ExceptionType.SERVER_PAYMENT_CANCEL_FAIL;
 import static nbc.mushroom.domain.common.exception.ExceptionType.SERVER_PAYMENT_FAIL;
 
@@ -9,13 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import nbc.mushroom.domain.bid.entity.Bid;
-import nbc.mushroom.domain.bid.repository.BidRepository;
-import nbc.mushroom.domain.common.dto.AuthUser;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.payment.dto.request.PaymentReq;
-import nbc.mushroom.domain.payment.dto.response.PaymentRes;
-import nbc.mushroom.domain.user.entity.User;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -23,7 +16,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -47,32 +39,8 @@ public class PaymentService {
     private static final String WIDGET_SECRET_KEY_ENCODED = Base64.getEncoder()
         .encodeToString((WIDGET_SECRET_KEY + ":").getBytes(StandardCharsets.UTF_8));
 
-    private final BidRepository bidRepository;
-
-    @Transactional
-    public PaymentRes confirmPayment(AuthUser authUser, PaymentReq paymentReq) {
-        PaymentRes paymentRes = PaymentRes.from(sendPayment(paymentReq));
-
-        try {
-            User user = User.fromAuthUser(authUser);
-            Long bidId = Long.valueOf(paymentRes.orderId().substring(20));
-            Bid bid = bidRepository.findById(bidId)
-                .orElseThrow(() -> new CustomException(BID_NOT_FOUND));
-
-            if (!user.getId().equals(bid.getBidder().getId())) {
-                throw new CustomException(INVALID_PAYMENT_USER);
-            }
-
-            bid.paymentComplete(paymentRes.amount());
-            return paymentRes;
-        } catch (Exception e) {
-            cancelPayment(paymentRes.paymentKey(), e.getMessage(), paymentRes.amount());
-            throw e;
-        }
-    }
-
     // 토스서버에 결제 승인 요청
-    private Map<String, Object> sendPayment(PaymentReq paymentReq) {
+    public Map<String, Object> sendPayment(PaymentReq paymentReq) {
         // 요청 헤더 설정
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -99,7 +67,7 @@ public class PaymentService {
     }
 
     // 에러가 날 경우 결제를 취소
-    private void cancelPayment(String paymentKey, String reason, Long cancelAmount) {
+    public void cancelPayment(String paymentKey, String reason, Long cancelAmount) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set("Authorization", "Basic " + WIDGET_SECRET_KEY_ENCODED);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: false


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #147 

## 📝 요약

- 결제와 비즈니스 로직 트랜잭션을 분리했습니다.
- 순서를 `결제 승인 확인 -> 로직` 에서 `로직 선 반영 -> 결제 승인 확인 -> 실패시 로직 롤백` 방식으로 변경했습니다.

## 💬 참고사항

[관련 내용](https://yeim.notion.site/19f16458a6bf808fbe9cfb9dc5a1593f?pvs=4) 노션에 올려두었습니다!

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
