### PR TITLE
[Bug(bid)] 동시에 입찰할 때 메시지가 전송되는 오류 해결

### DIFF
--- a/src/main/java/nbc/mushroom/domain/bid/controller/CreateBidController.java
+++ b/src/main/java/nbc/mushroom/domain/bid/controller/CreateBidController.java
@@ -4,7 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
 import nbc.mushroom.domain.bid.dto.response.CreateBidRes;
-import nbc.mushroom.domain.bid.service.CreateBidService;
+import nbc.mushroom.domain.bid.service.CreateBidFacade;
 import nbc.mushroom.domain.common.annotation.Auth;
 import nbc.mushroom.domain.common.dto.ApiResponse;
 import nbc.mushroom.domain.common.dto.AuthUser;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auction-items/{auctionItemId}/bids")
 public class CreateBidController {
 
-    private final CreateBidService createBidService;
+    private final CreateBidFacade createBidFacade;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateBidRes>> createOrUpdateBid(
@@ -30,7 +30,7 @@ public class CreateBidController {
         @PathVariable Long auctionItemId,
         @Valid @RequestBody CreateBidReq createBidReq
     ) {
-        CreateBidRes createBidRes = createBidService.createOrUpdateBid(
+        CreateBidRes createBidRes = createBidFacade.createOrUpdateBid(
             User.fromAuthUser(authUser),
             auctionItemId,
             createBidReq);

--- a/src/main/java/nbc/mushroom/domain/bid/service/CreateBidFacade.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/CreateBidFacade.java
@@ -1,0 +1,32 @@
+package nbc.mushroom.domain.bid.service;
+
+import lombok.RequiredArgsConstructor;
+import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
+import nbc.mushroom.domain.bid.dto.response.CreateBidRes;
+import nbc.mushroom.domain.bid.entity.Bid;
+import nbc.mushroom.domain.chat.service.ChatService;
+import nbc.mushroom.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateBidFacade {
+
+    private final CreateBidService createBidService;
+    private final ChatService chatService;
+
+    public CreateBidRes createOrUpdateBid(
+        User bidder,
+        Long auctionItemId,
+        CreateBidReq createBidReq
+    ) {
+        Bid newBid = createBidService.createOrUpdateBid(bidder, auctionItemId, createBidReq);
+        chatService.sendBidAnnouncementMessage(
+            newBid.getAuctionItem().getId(),
+            newBid.getBidder(),
+            newBid.getBiddingPrice()
+        );
+
+        return CreateBidRes.from(newBid);
+    }
+}

--- a/src/main/java/nbc/mushroom/domain/bid/service/CreateBidService.java
+++ b/src/main/java/nbc/mushroom/domain/bid/service/CreateBidService.java
@@ -7,20 +7,16 @@ import static nbc.mushroom.domain.common.exception.ExceptionType.SELF_BIDDING_NO
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import nbc.mushroom.domain.auction_item.entity.AuctionItem;
 import nbc.mushroom.domain.auction_item.repository.AuctionItemRepository;
 import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
-import nbc.mushroom.domain.bid.dto.response.CreateBidRes;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.repository.BidRepository;
-import nbc.mushroom.domain.chat.service.ChatService;
 import nbc.mushroom.domain.common.exception.CustomException;
 import nbc.mushroom.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,10 +24,10 @@ public class CreateBidService {
 
     private final BidRepository bidRepository;
     private final AuctionItemRepository auctionItemRepository;
-    private final ChatService chatService;
+
 
     @Transactional(readOnly = false)
-    public CreateBidRes createOrUpdateBid(
+    public Bid createOrUpdateBid(
         User bidder,
         Long auctionItemId,
         CreateBidReq createBidReq
@@ -47,16 +43,8 @@ public class CreateBidService {
 
         // 이전 입찰이 조회되면 업데이트, 없으면 생성
         Optional<Bid> prevBid = bidRepository.findBidByUserAndAuctionItem(bidder, auctionItem);
-        Bid newBid = upsertBid(bidder, auctionItem, createBidReq, maxBid, prevBid);
 
-        // 입찰되었다는 메시지 전송
-        chatService.sendBidAnnouncementMessage(
-            auctionItem.getId(),
-            newBid.getBidder(),
-            newBid.getBiddingPrice()
-        );
-
-        return CreateBidRes.from(newBid);
+        return upsertBid(bidder, auctionItem, createBidReq, maxBid, prevBid);
     }
 
     private Bid upsertBid(

--- a/src/test/java/nbc/mushroom/domain/bid/service/CreateBidServiceTest.java
+++ b/src/test/java/nbc/mushroom/domain/bid/service/CreateBidServiceTest.java
@@ -2,8 +2,6 @@ package nbc.mushroom.domain.bid.service;
 
 import static nbc.mushroom.domain.user.entity.UserRole.USER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,7 +16,6 @@ import nbc.mushroom.domain.bid.dto.request.CreateBidReq;
 import nbc.mushroom.domain.bid.entity.Bid;
 import nbc.mushroom.domain.bid.entity.BiddingStatus;
 import nbc.mushroom.domain.bid.repository.BidRepository;
-import nbc.mushroom.domain.chat.service.ChatService;
 import nbc.mushroom.domain.user.entity.User;
 import nbc.mushroom.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -33,16 +30,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
 class CreateBidServiceTest {
-
-    @MockitoBean
-    private ChatService chatService;
 
     @Autowired
     private BidRepository bidRepository;
@@ -95,9 +88,6 @@ class CreateBidServiceTest {
         auctionItem.approve();
         auctionItem.start();
         auctionItemRepository.saveAndFlush(auctionItem);
-
-        // chatService 함수 호출이 redis 에 접근하지 않도록 설정
-        doNothing().when(chatService).sendBidAnnouncementMessage(any(), any(), any());
     }
 
     @AfterEach


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #151 

## 📝 요약

- CreateBidFacade 라는 친구를 만들어서, CreateBidSerivce에서 서비스 로직을 호출하고 ChatService에서 레디스를 통한 채팅 전송을 하도록 하여 트랜잭션을 분리했습니다.


## 💬 참고사항

<img width="822" alt="스크린샷 2025-03-14 오후 6 21 54" src="https://github.com/user-attachments/assets/6986fdda-6598-4cde-8da3-a38974f343a6" />

이렇게 분리했습니다.


## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
